### PR TITLE
ci: disable dependabot auto-PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
+# Dependabot disabled — dependency updates are managed manually.
+# To re-enable, set open-pull-requests-limit to a positive number.
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Sets open-pull-requests-limit to 0. Dependency updates will be managed manually.