### PR TITLE
fix: reject invalid runtime variable names

### DIFF
--- a/core/runtime_services.c
+++ b/core/runtime_services.c
@@ -60,14 +60,16 @@ int eos_rtsvc_set_variable(const char *name, const void *data, uint32_t size)
     if (!rtsvc_initialized) return EOS_ERR_GENERIC;
     if (size > EOS_RTSVC_MAX_VAR_SIZE) return EOS_ERR_FULL;
 
+    size_t name_len = strlen(name);
+    if (name_len == 0 || name_len >= EOS_RTSVC_MAX_VAR_NAME)
+        return EOS_ERR_INVALID;
+
     eos_runtime_var_t *var = find_var(name);
     if (!var) {
         if (var_count >= EOS_RTSVC_MAX_VARS) return EOS_ERR_FULL;
         var = &var_store[var_count++];
-        size_t nlen = strlen(name);
-        if (nlen >= EOS_RTSVC_MAX_VAR_NAME) nlen = EOS_RTSVC_MAX_VAR_NAME - 1;
-        memcpy(var->name, name, nlen);
-        var->name[nlen] = '\0';
+        memcpy(var->name, name, name_len);
+        var->name[name_len] = '\0';
     }
 
     memcpy(var->data, data, size);

--- a/include/eos_runtime_svc.h
+++ b/include/eos_runtime_svc.h
@@ -45,6 +45,7 @@ int eos_rtsvc_get_variable(const char *name, void *data, uint32_t *size);
 
 /**
  * Set a runtime variable.
+ * Names must contain 1 to EOS_RTSVC_MAX_VAR_NAME - 1 characters.
  */
 int eos_rtsvc_set_variable(const char *name, const void *data, uint32_t size);
 

--- a/tests/unit/test_runtime_svc.c
+++ b/tests/unit/test_runtime_svc.c
@@ -94,6 +94,24 @@ TEST(test_string_variable)
     ASSERT(strcmp(out, "hello boot") == 0);
 }
 
+TEST(test_reject_invalid_variable_names)
+{
+    uint32_t value = 42;
+    char long_name[EOS_RTSVC_MAX_VAR_NAME + 1];
+    memset(long_name, 'a', sizeof(long_name));
+    long_name[sizeof(long_name) - 1] = '\0';
+
+    ASSERT(eos_rtsvc_set_variable("", &value, sizeof(value)) == EOS_ERR_INVALID);
+    ASSERT(eos_rtsvc_set_variable(long_name, &value, sizeof(value)) == EOS_ERR_INVALID);
+
+    /* Invalid names must not consume slots in the fixed-size variable store. */
+    for (int i = 0; i < EOS_RTSVC_MAX_VARS; i++) {
+        char name[EOS_RTSVC_MAX_VAR_NAME];
+        snprintf(name, sizeof(name), "valid-%d", i);
+        ASSERT(eos_rtsvc_set_variable(name, &value, sizeof(value)) == EOS_OK);
+    }
+}
+
 TEST(test_next_boot_slot)
 {
     ASSERT(eos_rtsvc_get_next_boot() == EOS_SLOT_NONE);
@@ -118,10 +136,11 @@ int main(void)
     run_test_get_nonexistent();
     run_test_null_args();
     run_test_string_variable();
+    run_test_reject_invalid_variable_names();
     run_test_next_boot_slot();
     run_test_time();
 
-    tests_run = 8;
+    tests_run = 9;
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;
 }


### PR DESCRIPTION
## Problem

Runtime variable names longer than `EOS_RTSVC_MAX_VAR_NAME - 1` were silently truncated when stored.

Subsequent lookups use the original, non-truncated name and therefore cannot find the stored entry. Repeated attempts can create additional unreachable entries until the fixed-size variable store is exhausted. Empty names were also accepted.

## Solution

- Reject empty runtime variable names.
- Reject names that cannot fit in the fixed-size name buffer.
- Copy accepted names without silent truncation.
- Document the supported name-length constraint.
- Add regression tests covering empty and overlong names.
- Verify that rejected names do not consume variable-store slots.

## Testing

Built and executed the runtime-services unit test on a Windows host using CMake, Ninja, and Zig/Clang 21:

`cmake --build build/codex --target test_runtime_svc`

`ctest --test-dir build/codex -R "^test_runtime_svc$" --output-on-failure`

Result:

`100% tests passed, 1/1`

The runtime-services executable reports:

`9/9 tests passed`

The regression test was run against the previous implementation and failed before the validation was added.

## Additional considerations

The maximum accepted name length remains `EOS_RTSVC_MAX_VAR_NAME - 1` characters, preserving the existing fixed-size storage layout and null terminator.