### PR TITLE
fix: make Python test runner portable

### DIFF
--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -2,10 +2,20 @@
 import sys
 import subprocess
 
-def main():
+TEST_PATHS = (
+    "tests/unit",
+    "tests/functional",
+    "tests/performance",
+    "tests/simulation",
+)
+
+
+def run_tests():
     print("=== Running all production-ready tests via pytest ===")
-    result = subprocess.run(["pytest", "tests/unit", "tests/functional", "tests/performance", "tests/simulation", "-v"], capture_output=False)
-    sys.exit(result.returncode)
+    command = [sys.executable, "-m", "pytest", *TEST_PATHS, "-v"]
+    result = subprocess.run(command, capture_output=False)
+    return result.returncode
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(run_tests())

--- a/tests/unit/test_run_all_tests.py
+++ b/tests/unit/test_run_all_tests.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+
+import run_all_tests
+
+
+def test_runner_uses_current_python_interpreter(monkeypatch):
+    captured = {}
+
+    def fake_run(command, capture_output):
+        captured["command"] = command
+        captured["capture_output"] = capture_output
+        return SimpleNamespace(returncode=7)
+
+    monkeypatch.setattr(run_all_tests.subprocess, "run", fake_run)
+    monkeypatch.setattr(run_all_tests.sys, "executable", "current-python")
+
+    assert run_all_tests.run_tests() == 7
+    assert captured == {
+        "command": [
+            "current-python",
+            "-m",
+            "pytest",
+            *run_all_tests.TEST_PATHS,
+            "-v",
+        ],
+        "capture_output": False,
+    }


### PR DESCRIPTION
## Problem

`run_all_tests.py` invokes a bare `pytest` executable. This can fail on Windows, virtual environments, and systems where pytest is installed for the active Python interpreter but its script directory is not on `PATH`.

It also couples process termination directly to the runner logic, making the command construction difficult to test.

## Solution

- Invoke pytest through the active interpreter with `sys.executable -m pytest`.
- Centralize the test paths in `TEST_PATHS`.
- Return the subprocess exit code from a reusable `run_tests()` function.
- Preserve the exit code through `SystemExit` in script mode.
- Add a regression test for interpreter selection, arguments, and exit-code propagation.

## Testing

Executed the Python unit, functional, performance, and simulation suites:

`pytest tests/unit tests/functional tests/performance tests/simulation -q`

Result:

`6 passed`

The regression test was also run with the old bare `pytest` command and failed as expected.

## Additional considerations

Pytest must still be installed for the Python interpreter used to launch the script. This change removes the separate requirement that the pytest console script be discoverable on `PATH`.