### PR TITLE
Implement authenticated recovery log retrieval

### DIFF
--- a/core/recovery.c
+++ b/core/recovery.c
@@ -43,6 +43,8 @@
 #define RCVR_MAX_AUTH_FAILS  5
 #define RCVR_BACKOFF_BASE_MS 1000
 
+#define RCVR_LOG_MAX_ENTRIES 8
+
 /* Recovery protocol packet header */
 #ifdef _MSC_VER
 #pragma pack(push, 1)
@@ -79,6 +81,8 @@ extern int  eos_slot_erase(eos_slot_t slot);
 
 /* Forward declarations from boot_log */
 extern void eos_boot_log_append(uint32_t event, uint32_t slot, uint32_t detail);
+extern int eos_boot_log_read(uint32_t index, eos_boot_log_entry_t *out);
+extern uint32_t eos_boot_log_get_head(void);
 
 static int recovery_send_ack(void)
 {
@@ -103,6 +107,7 @@ static bool cmd_requires_auth(uint8_t cmd)
     case RCVR_CMD_VERIFY:
     case RCVR_CMD_BOOT:
     case RCVR_CMD_FACTORY:
+    case RCVR_CMD_LOG:
         return true;
     default:
         return false;
@@ -329,6 +334,85 @@ static int recovery_handle_factory_reset(eos_bootctl_t *bctl)
     return recovery_send_ack();
 }
 
+static int recovery_collect_boot_log_entries(
+    eos_boot_log_entry_t *entries_out,
+    uint16_t *entry_count_out
+)
+{
+    eos_boot_log_entry_t raw_entries[EOS_BOOT_LOG_MAX];
+    uint32_t valid_entry_count = 0;
+    uint32_t log_head;
+    uint16_t written_count = 0;
+
+    if (!entries_out || !entry_count_out)
+        return EOS_ERR_INVALID;
+
+    for (uint32_t i = 0; i < EOS_BOOT_LOG_MAX; i++) {
+        int rc = eos_boot_log_read(i, &raw_entries[i]);
+        if (rc != EOS_OK)
+            return rc;
+
+        if (raw_entries[i].event != 0)
+            valid_entry_count++;
+    }
+
+    log_head = eos_boot_log_get_head() % EOS_BOOT_LOG_MAX;
+
+    for (uint32_t i = 0; i < valid_entry_count; i++) {
+        uint32_t entry_index = (valid_entry_count == EOS_BOOT_LOG_MAX) ?
+                               ((log_head + i) % EOS_BOOT_LOG_MAX) : i;
+
+        if (raw_entries[entry_index].event == 0)
+            continue;
+
+        entries_out[written_count++] = raw_entries[entry_index];
+    }
+
+    *entry_count_out = written_count;
+    return EOS_OK;
+}
+
+static int recovery_handle_boot_log(uint32_t start_index, uint16_t requested_count)
+{
+    eos_boot_log_entry_t boot_log_entries[EOS_BOOT_LOG_MAX];
+    uint16_t total_entries = 0;
+    uint16_t response_entry_count;
+    int rc;
+
+    if (requested_count == 0)
+        requested_count = RCVR_LOG_MAX_ENTRIES;
+    if (requested_count > RCVR_LOG_MAX_ENTRIES)
+        requested_count = RCVR_LOG_MAX_ENTRIES;
+
+    rc = recovery_collect_boot_log_entries(boot_log_entries, &total_entries);
+    if (rc != EOS_OK)
+        return recovery_send_nack();
+    
+    if (start_index >= total_entries) {
+        uint8_t empty_response_header[3] = { RCVR_ACK, 0, 0 };
+        return eos_hal_uart_send(empty_response_header, sizeof(empty_response_header));
+    }
+
+    response_entry_count = (uint16_t)(total_entries - start_index);
+    if (response_entry_count > requested_count)
+        response_entry_count = requested_count;
+    
+    uint8_t response_header[3] = {
+        RCVR_ACK,
+        (uint8_t)(response_entry_count & 0xFF),
+        (uint8_t)((response_entry_count >> 8) & 0xFF)
+    };
+
+    rc = eos_hal_uart_send(response_header, sizeof(response_header));
+    if (rc != EOS_OK)
+        return rc;
+    
+    return eos_hal_uart_send(
+        &boot_log_entries[start_index],
+        response_entry_count * sizeof(boot_log_entries[0])
+    );
+}
+
 int eos_recovery_enter(eos_bootctl_t *bctl)
 {
     eos_boot_log_append(EOS_LOG_RECOVERY_ENTER, EOS_SLOT_NONE, 0);
@@ -392,6 +476,10 @@ int eos_recovery_enter(eos_bootctl_t *bctl)
 
         case RCVR_CMD_FACTORY:
             recovery_handle_factory_reset(bctl);
+            break;
+
+        case RCVR_CMD_LOG:
+            recovery_handle_boot_log(pkt.offset, pkt.len);
             break;
 
         default:

--- a/docs/installation_usage.md
+++ b/docs/installation_usage.md
@@ -155,14 +155,20 @@ void main(void) {
 ### Step 5: Pack and sign firmware image
 
 ```bash
+# Install Python tool dependencies
+python3 -m pip install -r requirements.txt
+
 # Pack firmware with eboot image header
 python tools/imgpack.py firmware.bin --output firmware.packed.bin
 
 # Sign the image
 python tools/sign_image.py firmware.packed.bin --key signing_key.pem
 
-# Flash to board
-python tools/uart_recovery.py --port /dev/ttyUSB0 firmware.packed.bin
+# Set the recovery shared secret used by the UART tool
+export EBOOT_RECOVERY_SECRET_HEX=<64-hex-char-secret>
+
+# Upload the image to slot B over UART recovery
+python tools/uart_recovery.py --port /dev/ttyUSB0 upload --slot B --image firmware.packed.bin
 ```
 
 ### Step 6: Confirm boot (in your app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 pyyaml>=6.0
+pytest>=9.0
+pyserial>=3.5

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -4,7 +4,19 @@ import subprocess
 
 def main():
     print("=== Running all production-ready tests via pytest ===")
-    result = subprocess.run(["pytest", "tests/unit", "tests/functional", "tests/performance", "tests/simulation", "-v"], capture_output=False)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest", 
+            "tests/unit", 
+            "tests/functional", 
+            "tests/performance", 
+            "tests/simulation", 
+            "-v"
+        ], 
+        capture_output=False
+    )
     sys.exit(result.returncode)
 
 if __name__ == "__main__":

--- a/tests/unit/test_uart_recovery.py
+++ b/tests/unit/test_uart_recovery.py
@@ -1,0 +1,102 @@
+import hashlib
+import importlib.util
+import struct
+import sys
+import types
+import uuid
+from pathlib import Path
+
+
+UART_RECOVERY_PATH = Path(__file__).resolve().parents[2] / "tools" / "uart_recovery.py"
+
+
+class FakeSerial:
+    def __init__(self, incoming=b""):
+        self.incoming = bytearray(incoming)
+        self.writes = []
+        self.closed = False
+
+    def read(self, size):
+        chunk = bytes(self.incoming[:size])
+        del self.incoming[:size]
+        return chunk
+
+    def write(self, data):
+        self.writes.append(bytes(data))
+        return len(data)
+
+    def close(self):
+        self.closed = True
+
+
+def load_uart_recovery_module(monkeypatch, fake_serial):
+    serial_module = types.ModuleType("serial")
+    serial_module.Serial = lambda *args, **kwargs: fake_serial
+    monkeypatch.setitem(sys.modules, "serial", serial_module)
+
+    module_name = f"uart_recovery_test_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, UART_RECOVERY_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module.time, "sleep", lambda _: None)
+    return module
+
+
+def test_auth_success_sends_expected_digest(monkeypatch):
+    secret = bytes(range(32))
+    challenge = bytes(range(32, 64))
+    fake_serial = FakeSerial(bytes([0xAA]) + challenge + bytes([0xAA]))
+    uart_recovery = load_uart_recovery_module(monkeypatch, fake_serial)
+
+    client = uart_recovery.RecoveryClient("dummy-port")
+
+    assert client.authenticate(secret.hex()) is True
+    assert fake_serial.writes[0] == struct.pack(
+        "<BBHI", uart_recovery.CMD_AUTH, 0, 0, 0
+    )
+    assert fake_serial.writes[1] == hashlib.sha256(challenge + secret).digest()
+
+
+def test_auth_rejects_invalid_secret_length(monkeypatch, capsys):
+    fake_serial = FakeSerial()
+    uart_recovery = load_uart_recovery_module(monkeypatch, fake_serial)
+
+    client = uart_recovery.RecoveryClient("dummy-port")
+
+    assert client.authenticate("00") is False
+    assert fake_serial.writes == []
+    assert "exactly 32 bytes" in capsys.readouterr().out
+
+
+def test_log_decodes_readable_entries(monkeypatch, capsys):
+    payload = b"".join(
+        [
+            struct.pack("<IIII", 100, 0x01, 0, 0),
+            struct.pack("<IIII", 200, 0x21, 0xFF, 3),
+        ]
+    )
+    header = bytes([0xAA]) + struct.pack("<H", 2)
+    fake_serial = FakeSerial(header + payload)
+    uart_recovery = load_uart_recovery_module(monkeypatch, fake_serial)
+
+    client = uart_recovery.RecoveryClient("dummy-port")
+
+    assert client.read_boot_log(0, 2) is True
+    output = capsys.readouterr().out
+    assert "BOOT_START" in output
+    assert "AUTH_FAIL" in output
+    assert "slot=A" in output
+    assert "slot=NONE" in output
+
+
+def test_log_rejects_incomplete_payload(monkeypatch, capsys):
+    payload = struct.pack("<IIII", 100, 0x01, 0, 0)
+    header = bytes([0xAA]) + struct.pack("<H", 2)
+    fake_serial = FakeSerial(header + payload)
+    uart_recovery = load_uart_recovery_module(monkeypatch, fake_serial)
+
+    client = uart_recovery.RecoveryClient("dummy-port")
+
+    assert client.read_boot_log(0, 2) is False
+    assert "Incomplete log response" in capsys.readouterr().out

--- a/tools/uart_recovery.py
+++ b/tools/uart_recovery.py
@@ -24,6 +24,8 @@ import argparse
 import struct
 import sys
 import time
+import hashlib
+import os
 
 try:
     import serial
@@ -52,7 +54,38 @@ TIMEOUT = 5.0
 
 SLOT_MAP = {'A': 0, 'B': 1, 'a': 0, 'b': 1}
 
+CMD_AUTH = 0x10
+CHALLENGE_SIZE = 32
+RECOVERY_SECRET_SIZE = 32
+BOOT_LOG_ENTRY_SIZE = 16
 
+BOOT_LOG_EVENT_NAMES = {
+    0x01: "BOOT_START",
+    0x02: "IMAGE_VALID",
+    0x03: "IMAGE_INVALID",
+    0x04: "SLOT_SELECTED",
+    0x05: "ROLLBACK",
+    0x06: "RECOVERY_ENTER",
+    0x07: "UPGRADE_START",
+    0x08: "UPGRADE_DONE",
+    0x09: "CONFIRM",
+    0x0A: "FACTORY_RESET",
+    0x0B: "WATCHDOG_RESET",
+    0x0C: "BOOT_FAIL",
+    0x20: "AUTH_SUCCESS",
+    0x21: "AUTH_FAIL",
+}
+
+BOOT_LOG_SLOT_NAMES = {
+    0: "A",
+    1: "B",
+    2: "RECOVERY",
+    0xFF: "NONE",
+}
+
+def _boot_log_event_name(event: int) -> str:
+    return BOOT_LOG_EVENT_NAMES.get(event, f"UNKNOWN(0x{event:02X})")
+   
 class RecoveryClient:
     def __init__(self, port: str, baud: int = 115200):
         self.ser = serial.Serial(port, baud, timeout=TIMEOUT)
@@ -176,11 +209,78 @@ class RecoveryClient:
         print("Factory reset failed")
         return False
 
+    def authenticate(self, secret_hex: str) -> bool:
+        try:
+            shared_secret = bytes.fromhex(secret_hex)
+        except ValueError:
+            print("Recovery secret must be valid hex")
+            return False
+
+        if len(shared_secret) != RECOVERY_SECRET_SIZE:
+            print("Recovery secret must be exactly 32 bytes")
+            return False
+
+        self._send_packet(CMD_AUTH)
+        response = self.ser.read(1 + CHALLENGE_SIZE)
+        if len(response) != 1 + CHALLENGE_SIZE or response[0] != ACK:
+            print("Failed to get auth challenge")
+            return False
+
+        challenge = response[1:]
+        response_digest = hashlib.sha256(challenge + shared_secret).digest()
+
+        self.ser.write(response_digest)
+
+        if self._read_ack():
+            print("Authenticated")
+            return True
+
+        print("Authentication failed")
+        return False
+
+    def read_boot_log(self, start_index: int = 0, max_entries: int = 8) -> bool:
+        self._send_packet(CMD_LOG, length=max_entries, offset=start_index)
+
+        header = self.ser.read(3)
+        if len(header) != 3 or header[0] != ACK:
+            print("Log request failed")
+            return False
+
+        entry_count = struct.unpack('<H', header[1:3])[0]
+        payload = self.ser.read(entry_count * BOOT_LOG_ENTRY_SIZE)
+        if len(payload) != entry_count * BOOT_LOG_ENTRY_SIZE:
+            print("Incomplete log response")
+            return False
+
+        if entry_count == 0:
+            print("No log entries returned")
+            return True
+
+        for i in range(entry_count):
+            chunk = payload[
+                i * BOOT_LOG_ENTRY_SIZE:(i + 1) * BOOT_LOG_ENTRY_SIZE
+            ]
+            timestamp, event, slot, detail = struct.unpack('<IIII', chunk)
+
+            print(
+                f"[{start_index + i:02d}] "
+                f"t={timestamp:>8} "
+                f"event={_boot_log_event_name(event):<15} "
+                f"slot={BOOT_LOG_SLOT_NAMES.get(slot, hex(slot)):<8} "
+                f"detail=0x{detail:08X}"
+            )
+
+        return True
 
 def main():
     parser = argparse.ArgumentParser(description='eBootloader UART Recovery Tool')
     parser.add_argument('--port', '-p', required=True, help='Serial port (e.g., COM3 or /dev/ttyUSB0)')
     parser.add_argument('--baud', '-b', type=int, default=115200, help='Baud rate')
+    parser.add_argument(
+        '--secret-hex',
+        default=os.environ.get('EBOOT_RECOVERY_SECRET_HEX'),
+        help='32-byte recovery secret as hex; defaults to EBOOT_RECOVERY_SECRET_HEX'
+    )
 
     subparsers = parser.add_subparsers(dest='command', required=True)
 
@@ -202,9 +302,23 @@ def main():
     boot_p = subparsers.add_parser('boot', help='Boot into slot')
     boot_p.add_argument('--slot', '-s', required=True, choices=['A', 'B'], help='Target slot')
 
+    log_p = subparsers.add_parser('log', help='Read boot log')
+    log_p.add_argument('--start', type=int, default=0, help='Start log index')
+    log_p.add_argument('--count', type=int, default=8, help='Number of entries to request')
+
     args = parser.parse_args()
 
     client = RecoveryClient(args.port, args.baud)
+
+    protected_commands = {'erase', 'upload', 'verify', 'boot', 'factory-reset', 'log'}
+
+    if args.command in protected_commands:
+        if not args.secret_hex:
+            print("This command requires --secret-hex or EBOOT_RECOVERY_SECRET_HEX", file=sys.stderr)
+            sys.exit(1)
+
+        if not client.authenticate(args.secret_hex):
+            sys.exit(1)
 
     try:
         if args.command == 'ping':
@@ -228,6 +342,8 @@ def main():
             success = client.reset()
         elif args.command == 'factory-reset':
             success = client.factory_reset()
+        elif args.command == 'log':
+            success = client.read_boot_log(args.start, args.count)
         else:
             success = False
 
@@ -235,7 +351,6 @@ def main():
 
     finally:
         client.close()
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary

This PR implements the missing recovery `LOG` command in `eBoot`, protects it behind the existing recovery authentication flow, adds host-side support to request and decode boot logs, includes unit tests for the new UART recovery client behavior, and fixes the documented Python test setup so the local test runner works reliably in a virtual environment.

## Issue / Improvement Being Addressed

`eBoot` advertised a recovery `LOG` command in the UART protocol, but the feature was incomplete:

- `RCVR_CMD_LOG` was defined in `core/recovery.c`, but there was no command handler in the recovery command switch.
- The host recovery tool (`tools/uart_recovery.py`) defined `CMD_LOG`, but it had no implementation for authentication or log retrieval.
- As a result, the protocol claimed to support boot-log retrieval, but users could not actually request or inspect logs from recovery mode.

This PR closes that gap and turns `LOG` into a usable, testable recovery feature.

This PR also fixes a separate Python tooling issue:

- `run_all_tests.py` invoked `pytest` directly from `PATH`
- `requirements.txt` did not declare `pytest`
- on a fresh environment, the documented `python run_all_tests.py` flow could fail even when users followed the repository instructions

## Proposed Approach and Implementation

### Proposed approach

My approach was to treat this as a missing-but-already-intended recovery feature rather than introducing a brand-new subsystem.

The recovery protocol already defined a `LOG` command, and the codebase already had:

- persistent boot-log storage
- a recovery authentication flow
- a host-side UART recovery tool

So instead of redesigning recovery, I completed the existing feature path end to end.

In practical terms, the approach was:

1. Implement the missing firmware-side `LOG` command handler.
2. Reuse the existing recovery authentication flow and require authentication before log retrieval.
3. Return structured boot-log entries rather than raw flash bytes.
4. Extend the host recovery tool so it can authenticate, request logs, and decode them into readable output.
5. Add host-side unit tests using simulated serial responses so the new behavior can be validated without requiring physical hardware.
6. Fix the documented Python test-runner dependency path so local validation works reliably in a fresh environment.

This approach keeps the change focused, useful, and easy to review:

- it closes a real gap in the documented recovery protocol
- it improves diagnostics without broadening recovery access
- it reuses existing project mechanisms instead of adding unnecessary complexity
- it provides practical validation even when hardware is not available locally

### Firmware-side recovery changes

In `core/recovery.c`:

- Added `RCVR_LOG_MAX_ENTRIES` to cap the number of log entries returned in one response.
- Added forward declarations for:
  - `eos_boot_log_read(...)`
  - `eos_boot_log_get_head()`
- Updated `cmd_requires_auth(...)` so that `RCVR_CMD_LOG` requires authentication.
- Added `recovery_collect_boot_log_entries(...)` to:
  - read structured boot-log entries from flash
  - skip empty entries
  - reorder the ring buffer into readable chronological output
- Added `recovery_handle_boot_log(...)` to:
  - accept `start` and `requested` values from the recovery packet
  - bound the response size
  - send a compact response header
  - send the selected boot-log entries back over UART
- Wired `RCVR_CMD_LOG` into the recovery command switch.
- Added error handling so log-collection failures return `NACK`.

### Host recovery tool changes

In `tools/uart_recovery.py`:

- Added support for `CMD_AUTH` and the current challenge-response flow used by `eBoot`.
- Added:
  - `authenticate(secret_hex)`
  - `read_boot_log(start_index, max_entries)`
- Added event/slot decoding tables so raw numeric boot-log entries are printed in readable form.
- Added CLI support for:
  - `log`
  - `--secret-hex`
- Required authentication before protected commands, including `log`.
- Improved validation and error handling for:
  - invalid secret length
  - failed challenge retrieval
  - truncated log payloads

### Tests

Added `tests/unit/test_uart_recovery.py` with simulated serial tests for the host recovery client:

- auth success path
- invalid secret rejection
- readable log decoding
- incomplete log response handling

These tests validate the UART recovery client logic without requiring hardware.

### Python test setup changes

In `run_all_tests.py` and `requirements.txt`:

- updated the test runner to invoke `pytest` via `sys.executable -m pytest`
- added `pytest` to `requirements.txt`
- added `pyserial` to `requirements.txt` so the UART recovery client dependency is installed through the standard Python setup flow

## Code Changes

### Files changed for this PR

- `core/recovery.c`
  - implemented authenticated recovery log retrieval on the firmware side
- `tools/uart_recovery.py`
  - implemented authentication and log retrieval on the host side
- `tests/unit/test_uart_recovery.py`
  - added real unit tests using a fake serial transport
- `run_all_tests.py`
  - updated the test runner to use `sys.executable -m pytest`
- `requirements.txt`
  - added `pytest` and `pyserial` so both the documented test runner and UART recovery client dependencies are installed through the standard Python setup flow

## Testing / Validation Performed

### Local validation completed

1. Python syntax validation

```bash
python3 -m py_compile tools/uart_recovery.py
```

2. Native build validation

```bash
cmake --build build-local -j4
```

3. Native C test suite

```bash
ctest --test-dir build-local --output-on-failure
```

Result: `11/11` tests passed.

4. New UART recovery unit tests

```bash
./.venv/bin/pytest tests/unit/test_uart_recovery.py -v
```

Result: `4/4` tests passed.

5. Existing Python test suite

```bash
./.venv/bin/pytest tests/unit tests/functional tests/performance tests/simulation -v
```

Result: `9/9` tests passed.

6. Documented Python test runner flow

```bash
python3 run_all_tests.py
```

Result: now works correctly when `requirements.txt` has been installed into the active environment.

### What the new tests prove

The new unit tests verify that:

- the host tool sends the correct `AUTH` packet
- the host tool computes the expected digest for the current recovery auth flow
- invalid secrets are rejected before serial traffic begins
- boot-log entries are decoded into readable output
- malformed or truncated log responses fail safely

### Dependency validation

- Added `pytest>=9.0` to `requirements.txt` because `run_all_tests.py` depends on pytest and the documented local test flow should not rely on a globally installed binary.
- Added `pyserial>=3.5` to `requirements.txt` because `tools/uart_recovery.py` imports `serial` at startup and cannot run without it.
- This keeps the recovery tool aligned with the repository's normal Python installation flow:

```bash
python3 -m pip install -r requirements.txt
```

## Additional Considerations / Limitations

- Full end-to-end hardware validation of the UART recovery path was not completed locally because no physical serial device was detected on the development machine beyond `/dev/cu.Bluetooth-Incoming-Port`.
- The recovery authentication flow reused in this PR matches the current implementation in `core/recovery.c`, which computes `SHA256(challenge || shared_secret)`. This is consistent with the existing code path, but it is not a true HMAC construction. A future hardening PR could replace it with a standard HMAC-based implementation.

## Reviewer Notes

The main value of this PR is that it converts a documented-but-nonfunctional recovery command into a real feature:

- the firmware can now return boot logs
- the host tool can authenticate and request them
- the behavior is covered by unit tests
- the feature is gated behind authentication to avoid exposing diagnostic data over an open recovery interface
