### PR TITLE
fix(core): return valid slot count from scan

### DIFF
--- a/core/slot_manager.c
+++ b/core/slot_manager.c
@@ -56,9 +56,10 @@ static int verify_slot(eos_slot_t slot)
 
 int eos_slot_scan_all(void)
 {
-    verify_slot(EOS_SLOT_A);
-    verify_slot(EOS_SLOT_B);
-    return EOS_OK;
+    int valid = 0;
+    if (verify_slot(EOS_SLOT_A) == EOS_OK) valid++;
+    if (verify_slot(EOS_SLOT_B) == EOS_OK) valid++;
+    return valid;
 }
 
 eos_slot_state_t eos_slot_get_state(eos_slot_t slot)

--- a/tests/unit/test_slot_manager.c
+++ b/tests/unit/test_slot_manager.c
@@ -1,281 +1,199 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 EoS Project
 // ISO/IEC 25000 | ISO/IEC/IEEE 15288:2023
+
 /**
  * @file test_slot_manager.c
- * @brief Unit tests for firmware slot manager
+ * @brief Unit tests for the production firmware slot manager
  */
-#include <stdio.h>
-#include <string.h>
-#include <assert.h>
+
+#include "eos_hal.h"
 #include "eos_slot_manager.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-static int passed = 0;
-#define PASS(name) do { printf("[PASS] %s\n", name); passed++; } while(0)
+#define SLOT_A_ADDR 0x10000u
+#define SLOT_B_ADDR 0x30000u
+#define SLOT_SIZE   0x10000u
 
-/* ---- Simulated Flash Backend ---- */
-#define SIM_FLASH_SIZE   (256 * 1024)
-static uint8_t sim_flash[SIM_FLASH_SIZE];
+static int parse_result[2];
+static int integrity_result[2];
+static int signature_result[2];
+static uint32_t slot_version[2];
+static int erase_result;
+static uint32_t erased_addr;
+static size_t erased_size;
+static int tests_passed;
 
-#define SLOT_A_OFFSET   0x10000
-#define SLOT_B_OFFSET   0x30000
-#define SLOT_REC_OFFSET 0x20000
+#define ASSERT(condition)                                                     \
+    do {                                                                      \
+        if (!(condition)) {                                                   \
+            fprintf(stderr, "[FAIL] %s:%d: %s\n",                          \
+                    __FILE__, __LINE__, #condition);                          \
+            exit(1);                                                          \
+        }                                                                     \
+    } while (0)
 
-static eos_slot_state_t slot_states[3] = {
-    EOS_SLOT_STATE_EMPTY, EOS_SLOT_STATE_EMPTY, EOS_SLOT_STATE_EMPTY
-};
-static uint32_t slot_versions[3] = {0, 0, 0};
+#define RUN(test)                                                             \
+    do {                                                                      \
+        reset_fixture();                                                      \
+        test();                                                               \
+        tests_passed++;                                                       \
+        printf("[PASS] %s\n", #test);                                       \
+    } while (0)
 
-/* ---- Stub implementations ---- */
-int eos_slot_scan_all(void) {
-    int valid = 0;
-    for (int i = 0; i < 3; i++) {
-        if (slot_states[i] == EOS_SLOT_STATE_VALID ||
-            slot_states[i] == EOS_SLOT_STATE_CONFIRMED)
-            valid++;
+static int slot_index(uint32_t addr)
+{
+    if (addr == SLOT_A_ADDR) return EOS_SLOT_A;
+    if (addr == SLOT_B_ADDR) return EOS_SLOT_B;
+    return -1;
+}
+
+static void reset_fixture(void)
+{
+    for (int i = 0; i < 2; i++) {
+        parse_result[i] = EOS_ERR_NO_IMAGE;
+        integrity_result[i] = EOS_OK;
+        signature_result[i] = EOS_OK;
+        slot_version[i] = 0;
     }
-    return valid;
+    erase_result = EOS_OK;
+    erased_addr = 0;
+    erased_size = 0;
 }
 
-bool eos_slot_is_valid(eos_slot_t slot) {
-    if (slot > EOS_SLOT_RECOVERY) return false;
-    return (slot_states[slot] == EOS_SLOT_STATE_VALID ||
-            slot_states[slot] == EOS_SLOT_STATE_CONFIRMED);
+uint32_t eos_hal_slot_addr(eos_slot_t slot)
+{
+    if (slot == EOS_SLOT_A) return SLOT_A_ADDR;
+    if (slot == EOS_SLOT_B) return SLOT_B_ADDR;
+    return 0;
 }
 
-uint32_t eos_slot_get_version(eos_slot_t slot) {
-    if (slot > EOS_SLOT_RECOVERY) return 0;
-    if (slot_states[slot] == EOS_SLOT_STATE_EMPTY) return 0;
-    return slot_versions[slot];
+uint32_t eos_hal_slot_size(eos_slot_t slot)
+{
+    return slot <= EOS_SLOT_B ? SLOT_SIZE : 0;
 }
 
-int eos_slot_get_header(eos_slot_t slot, eos_image_header_t *out) {
-    if (slot > EOS_SLOT_RECOVERY || !out) return EOS_ERR_INVALID;
-    if (slot_states[slot] == EOS_SLOT_STATE_EMPTY) return EOS_ERR_NO_IMAGE;
+int eos_hal_flash_erase(uint32_t addr, size_t len)
+{
+    erased_addr = addr;
+    erased_size = len;
+    return erase_result;
+}
+
+int eos_image_parse_header(uint32_t addr, eos_image_header_t *out)
+{
+    int slot = slot_index(addr);
+    if (slot < 0 || !out) return EOS_ERR_INVALID;
+    if (parse_result[slot] != EOS_OK) return parse_result[slot];
+
     memset(out, 0, sizeof(*out));
     out->magic = EOS_IMG_MAGIC;
-    out->image_version = slot_versions[slot];
+    out->image_version = slot_version[slot];
+    out->reserved[0] = (uint8_t)slot;
     return EOS_OK;
 }
 
-eos_slot_state_t eos_slot_get_state(eos_slot_t slot) {
-    if (slot > EOS_SLOT_RECOVERY) return EOS_SLOT_STATE_EMPTY;
-    return slot_states[slot];
+int eos_image_verify_integrity(const eos_image_header_t *hdr, uint32_t addr)
+{
+    int slot = slot_index(addr);
+    if (!hdr || slot < 0) return EOS_ERR_INVALID;
+    return integrity_result[slot];
 }
 
-int eos_slot_erase(eos_slot_t slot) {
-    if (slot > EOS_SLOT_RECOVERY) return EOS_ERR_INVALID;
-    slot_states[slot] = EOS_SLOT_STATE_EMPTY;
-    slot_versions[slot] = 0;
-    return EOS_OK;
+int eos_image_verify_signature(const eos_image_header_t *hdr)
+{
+    if (!hdr || hdr->reserved[0] > EOS_SLOT_B) return EOS_ERR_INVALID;
+    return signature_result[hdr->reserved[0]];
 }
 
-/* ---- Helper ---- */
-static void reset_slots(void) {
-    memset(sim_flash, 0xFF, SIM_FLASH_SIZE);
-    for (int i = 0; i < 3; i++) {
-        slot_states[i] = EOS_SLOT_STATE_EMPTY;
-        slot_versions[i] = 0;
-    }
+static void make_valid(eos_slot_t slot, uint32_t version)
+{
+    parse_result[slot] = EOS_OK;
+    slot_version[slot] = version;
 }
 
-/* ---- Tests ---- */
-static void test_scan_no_valid_slots(void) {
-    reset_slots();
-    int count = eos_slot_scan_all();
-    assert(count == 0);
-    PASS("scan_no_valid_slots");
+static void test_scan_no_valid_slots(void)
+{
+    ASSERT(eos_slot_scan_all() == 0);
+    ASSERT(eos_slot_get_state(EOS_SLOT_A) == EOS_SLOT_STATE_EMPTY);
+    ASSERT(eos_slot_get_state(EOS_SLOT_B) == EOS_SLOT_STATE_EMPTY);
 }
 
-static void test_scan_one_valid_slot(void) {
-    reset_slots();
-    slot_states[EOS_SLOT_A] = EOS_SLOT_STATE_VALID;
-    slot_versions[EOS_SLOT_A] = EOS_VERSION_MAKE(1, 0, 0);
-    int count = eos_slot_scan_all();
-    assert(count == 1);
-    PASS("scan_one_valid_slot");
+static void test_scan_one_valid_slot(void)
+{
+    make_valid(EOS_SLOT_A, EOS_VERSION_MAKE(1, 2, 3));
+
+    ASSERT(eos_slot_scan_all() == 1);
+    ASSERT(eos_slot_is_valid(EOS_SLOT_A));
+    ASSERT(!eos_slot_is_valid(EOS_SLOT_B));
+    ASSERT(eos_slot_get_version(EOS_SLOT_A) == EOS_VERSION_MAKE(1, 2, 3));
+
+    eos_image_header_t header;
+    ASSERT(eos_slot_get_header(EOS_SLOT_A, &header) == EOS_OK);
+    ASSERT(header.image_version == EOS_VERSION_MAKE(1, 2, 3));
 }
 
-static void test_scan_two_valid_slots(void) {
-    reset_slots();
-    slot_states[EOS_SLOT_A] = EOS_SLOT_STATE_VALID;
-    slot_states[EOS_SLOT_B] = EOS_SLOT_STATE_CONFIRMED;
-    slot_versions[EOS_SLOT_A] = EOS_VERSION_MAKE(1, 0, 0);
-    slot_versions[EOS_SLOT_B] = EOS_VERSION_MAKE(2, 0, 0);
-    int count = eos_slot_scan_all();
-    assert(count == 2);
-    PASS("scan_two_valid_slots");
+static void test_scan_two_valid_slots(void)
+{
+    make_valid(EOS_SLOT_A, EOS_VERSION_MAKE(1, 0, 0));
+    make_valid(EOS_SLOT_B, EOS_VERSION_MAKE(2, 0, 0));
+
+    ASSERT(eos_slot_scan_all() == 2);
+    ASSERT(eos_slot_is_valid(EOS_SLOT_A));
+    ASSERT(eos_slot_is_valid(EOS_SLOT_B));
+    ASSERT(eos_slot_get_version(EOS_SLOT_B) == EOS_VERSION_MAKE(2, 0, 0));
 }
 
-static void test_scan_all_slots_valid(void) {
-    reset_slots();
-    slot_states[EOS_SLOT_A] = EOS_SLOT_STATE_VALID;
-    slot_states[EOS_SLOT_B] = EOS_SLOT_STATE_VALID;
-    slot_states[EOS_SLOT_RECOVERY] = EOS_SLOT_STATE_CONFIRMED;
-    int count = eos_slot_scan_all();
-    assert(count == 3);
-    PASS("scan_all_slots_valid");
+static void test_verification_failures_are_invalid(void)
+{
+    make_valid(EOS_SLOT_A, EOS_VERSION_MAKE(1, 0, 0));
+    make_valid(EOS_SLOT_B, EOS_VERSION_MAKE(2, 0, 0));
+    integrity_result[EOS_SLOT_A] = EOS_ERR_CRC;
+    signature_result[EOS_SLOT_B] = EOS_ERR_SIGNATURE;
+
+    ASSERT(eos_slot_scan_all() == 0);
+    ASSERT(eos_slot_get_state(EOS_SLOT_A) == EOS_SLOT_STATE_INVALID);
+    ASSERT(eos_slot_get_state(EOS_SLOT_B) == EOS_SLOT_STATE_INVALID);
+    ASSERT(eos_slot_get_header(EOS_SLOT_A, NULL) == EOS_ERR_INVALID);
 }
 
-static void test_slot_is_valid_empty(void) {
-    reset_slots();
-    assert(!eos_slot_is_valid(EOS_SLOT_A));
-    PASS("slot_is_valid_empty");
+static void test_invalid_slot_is_rejected(void)
+{
+    ASSERT(!eos_slot_is_valid(EOS_SLOT_RECOVERY));
+    ASSERT(eos_slot_get_state(EOS_SLOT_RECOVERY) == EOS_SLOT_STATE_EMPTY);
+    ASSERT(eos_slot_get_version(EOS_SLOT_RECOVERY) == 0);
+    ASSERT(eos_slot_get_header(EOS_SLOT_RECOVERY, NULL) == EOS_ERR_INVALID);
+    ASSERT(eos_slot_erase(EOS_SLOT_RECOVERY) == EOS_ERR_INVALID);
 }
 
-static void test_slot_is_valid_with_image(void) {
-    reset_slots();
-    slot_states[EOS_SLOT_A] = EOS_SLOT_STATE_VALID;
-    assert(eos_slot_is_valid(EOS_SLOT_A));
-    PASS("slot_is_valid_with_image");
+static void test_erase_updates_state_only_on_success(void)
+{
+    make_valid(EOS_SLOT_A, EOS_VERSION_MAKE(1, 0, 0));
+    ASSERT(eos_slot_scan_all() == 1);
+
+    erase_result = EOS_ERR_FLASH;
+    ASSERT(eos_slot_erase(EOS_SLOT_A) == EOS_ERR_FLASH);
+    ASSERT(eos_slot_is_valid(EOS_SLOT_A));
+
+    erase_result = EOS_OK;
+    ASSERT(eos_slot_erase(EOS_SLOT_A) == EOS_OK);
+    ASSERT(erased_addr == SLOT_A_ADDR);
+    ASSERT(erased_size == SLOT_SIZE);
+    ASSERT(eos_slot_get_state(EOS_SLOT_A) == EOS_SLOT_STATE_EMPTY);
+    ASSERT(eos_slot_get_version(EOS_SLOT_A) == 0);
 }
 
-static void test_slot_is_valid_confirmed(void) {
-    reset_slots();
-    slot_states[EOS_SLOT_B] = EOS_SLOT_STATE_CONFIRMED;
-    assert(eos_slot_is_valid(EOS_SLOT_B));
-    PASS("slot_is_valid_confirmed");
-}
-
-static void test_slot_is_valid_invalid_state(void) {
-    reset_slots();
-    slot_states[EOS_SLOT_A] = EOS_SLOT_STATE_INVALID;
-    assert(!eos_slot_is_valid(EOS_SLOT_A));
-    PASS("slot_is_valid_invalid_state");
-}
-
-static void test_slot_get_version_empty(void) {
-    reset_slots();
-    uint32_t ver = eos_slot_get_version(EOS_SLOT_A);
-    assert(ver == 0);
-    PASS("slot_get_version_empty");
-}
-
-static void test_slot_get_version_with_image(void) {
-    reset_slots();
-    slot_states[EOS_SLOT_A] = EOS_SLOT_STATE_VALID;
-    slot_versions[EOS_SLOT_A] = EOS_VERSION_MAKE(2, 3, 5);
-    uint32_t ver = eos_slot_get_version(EOS_SLOT_A);
-    assert(EOS_VERSION_MAJOR(ver) == 2);
-    assert(EOS_VERSION_MINOR(ver) == 3);
-    assert(EOS_VERSION_PATCH(ver) == 5);
-    PASS("slot_get_version_with_image");
-}
-
-static void test_slot_get_state_empty(void) {
-    reset_slots();
-    eos_slot_state_t state = eos_slot_get_state(EOS_SLOT_A);
-    assert(state == EOS_SLOT_STATE_EMPTY);
-    PASS("slot_get_state_empty");
-}
-
-static void test_slot_get_state_valid(void) {
-    reset_slots();
-    slot_states[EOS_SLOT_B] = EOS_SLOT_STATE_VALID;
-    assert(eos_slot_get_state(EOS_SLOT_B) == EOS_SLOT_STATE_VALID);
-    PASS("slot_get_state_valid");
-}
-
-static void test_slot_get_state_testing(void) {
-    reset_slots();
-    slot_states[EOS_SLOT_A] = EOS_SLOT_STATE_TESTING;
-    assert(eos_slot_get_state(EOS_SLOT_A) == EOS_SLOT_STATE_TESTING);
-    PASS("slot_get_state_testing");
-}
-
-static void test_slot_erase(void) {
-    reset_slots();
-    slot_states[EOS_SLOT_A] = EOS_SLOT_STATE_VALID;
-    slot_versions[EOS_SLOT_A] = EOS_VERSION_MAKE(1, 0, 0);
-    int rc = eos_slot_erase(EOS_SLOT_A);
-    assert(rc == EOS_OK);
-    assert(eos_slot_get_state(EOS_SLOT_A) == EOS_SLOT_STATE_EMPTY);
-    assert(eos_slot_get_version(EOS_SLOT_A) == 0);
-    PASS("slot_erase");
-}
-
-static void test_slot_erase_already_empty(void) {
-    reset_slots();
-    int rc = eos_slot_erase(EOS_SLOT_B);
-    assert(rc == EOS_OK);
-    PASS("slot_erase_already_empty");
-}
-
-static void test_slot_get_header_valid(void) {
-    reset_slots();
-    slot_states[EOS_SLOT_A] = EOS_SLOT_STATE_VALID;
-    slot_versions[EOS_SLOT_A] = EOS_VERSION_MAKE(3, 1, 0);
-    eos_image_header_t hdr;
-    int rc = eos_slot_get_header(EOS_SLOT_A, &hdr);
-    assert(rc == EOS_OK);
-    assert(hdr.magic == EOS_IMG_MAGIC);
-    assert(hdr.image_version == EOS_VERSION_MAKE(3, 1, 0));
-    PASS("slot_get_header_valid");
-}
-
-static void test_slot_get_header_empty(void) {
-    reset_slots();
-    eos_image_header_t hdr;
-    int rc = eos_slot_get_header(EOS_SLOT_A, &hdr);
-    assert(rc == EOS_ERR_NO_IMAGE);
-    PASS("slot_get_header_empty");
-}
-
-static void test_slot_get_header_null(void) {
-    reset_slots();
-    slot_states[EOS_SLOT_A] = EOS_SLOT_STATE_VALID;
-    int rc = eos_slot_get_header(EOS_SLOT_A, NULL);
-    assert(rc == EOS_ERR_INVALID);
-    PASS("slot_get_header_null");
-}
-
-static void test_version_macro_encoding(void) {
-    uint32_t v = EOS_VERSION_MAKE(1, 2, 3);
-    assert(EOS_VERSION_MAJOR(v) == 1);
-    assert(EOS_VERSION_MINOR(v) == 2);
-    assert(EOS_VERSION_PATCH(v) == 3);
-    PASS("version_macro_encoding");
-}
-
-static void test_version_macro_max_values(void) {
-    uint32_t v = EOS_VERSION_MAKE(255, 255, 65535);
-    assert(EOS_VERSION_MAJOR(v) == 255);
-    assert(EOS_VERSION_MINOR(v) == 255);
-    assert(EOS_VERSION_PATCH(v) == 65535);
-    PASS("version_macro_max_values");
-}
-
-static void test_slot_enum_values(void) {
-    assert(EOS_SLOT_A == 0);
-    assert(EOS_SLOT_B == 1);
-    assert(EOS_SLOT_RECOVERY == 2);
-    assert(EOS_SLOT_NONE == 0xFF);
-    PASS("slot_enum_values");
-}
-
-int main(void) {
-    printf("=== eboot Slot Manager Tests ===\n");
-    test_scan_no_valid_slots();
-    test_scan_one_valid_slot();
-    test_scan_two_valid_slots();
-    test_scan_all_slots_valid();
-    test_slot_is_valid_empty();
-    test_slot_is_valid_with_image();
-    test_slot_is_valid_confirmed();
-    test_slot_is_valid_invalid_state();
-    test_slot_get_version_empty();
-    test_slot_get_version_with_image();
-    test_slot_get_state_empty();
-    test_slot_get_state_valid();
-    test_slot_get_state_testing();
-    test_slot_erase();
-    test_slot_erase_already_empty();
-    test_slot_get_header_valid();
-    test_slot_get_header_empty();
-    test_slot_get_header_null();
-    test_version_macro_encoding();
-    test_version_macro_max_values();
-    test_slot_enum_values();
-    printf("\n=== ALL %d TESTS PASSED ===\n", passed);
+int main(void)
+{
+    printf("=== eBootloader Slot Manager Tests ===\n");
+    RUN(test_scan_no_valid_slots);
+    RUN(test_scan_one_valid_slot);
+    RUN(test_scan_two_valid_slots);
+    RUN(test_verification_failures_are_invalid);
+    RUN(test_invalid_slot_is_rejected);
+    RUN(test_erase_updates_state_only_on_success);
+    printf("\n%d/6 tests passed\n", tests_passed);
     return 0;
 }


### PR DESCRIPTION
## Problem

`eos_slot_scan_all()` is documented to return the number of valid firmware slots but always returned `EOS_OK` (zero). The existing slot-manager test reimplemented every public slot API inside the test executable, so it tested the fake implementation rather than `core/slot_manager.c`. Release builds also disabled its standard `assert()` checks through `NDEBUG`.

## Approach

- Count successful A/B verification results and return a value from 0 to 2.
- Replace public-API fakes with HAL and image-verification boundary stubs.
- Use assertions that remain active in Release builds.
- Cover zero, one, and two valid slots; state/header/version queries; integrity/signature failures; invalid recovery-slot requests; and erase success/failure.

No public signature or dependency changes are introduced.

## Validation

- Regression before fix: **failed as expected** at the one-valid-slot count.
- Release `test_slot_manager`: **6/6 passed**.
- ASan/UBSan `test_slot_manager`: **6/6 passed**.
- All independently buildable C tests except the baseline-blocked recovery target: **13/13 passed**.
- Python tests excluding the unrelated runner failure: **9 passed**.
- Config generation from a representative boot layout: **passed** and produced both generated files.
- `git diff --check`: **passed**.
- Independent review: **approved with no findings**.

## Additional considerations and limitations

The unmodified baseline full build already fails while linking `test_recovery` because `eos_boot_log_append`, `eos_boot_log_get_head`, and `eos_boot_log_read` are unresolved. The full Python suite also has one unrelated existing failure: `run_all_tests.run_tests()` raises `SystemExit` while its test expects a return value. This PR does not hide or expand into either issue. Validation was host-based; no hardware flashing was performed.

GitHub Actions created build, simulation, CodeQL, and assignment runs for this PR, but all are currently `action_required` pending maintainer approval.
