### PR TITLE
fix: link eboot_stage1 into test_recovery

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ add_test(NAME test_image_verify COMMAND test_image_verify)
 
 # --- test_recovery: UART recovery write range ---
 add_executable(test_recovery unit/test_recovery.c)
-target_link_libraries(test_recovery PRIVATE eboot_core)
+target_link_libraries(test_recovery PRIVATE eboot_core eboot_stage1)
 add_test(NAME test_recovery COMMAND test_recovery)
 
 # --- test_device_table: UEFI-style device table ---


### PR DESCRIPTION
test_recovery failed to link with undefined symbols for eos_boot_log_append, eos_boot_log_read, and eos_boot_log_get_head.

core/recovery.c calls these functions (declared via a local extern matching the real implementation), but the implementation lives in stage1/boot_log.c, which is built into the eboot_stage1 library — not eboot_core, which is all test_recovery was linked against.

Fix: link eboot_stage1 into test_recovery, matching the dependency recovery.c actually has at runtime.

Verified: ctest --test-dir build --output-on-failure now shows 14/14 tests passing (previously 13/14, with test_recovery Not Run due to the link failure).

Note: this produces a harmless linker warning ("ignoring duplicate libraries: '../libeboot_core.a'"), since eboot_stage1 already links eboot_core internally. Not addressed here — flagging for visibility rather than silently leaving it unmentioned.

Separately, while investigating this I found that include/eos_boot_log.h declares different signatures for eos_boot_log_init and eos_boot_log_read than what stage1/boot_log.c actually implements, and that test_boot_log.c's test doubles match the header's (incorrect) signature rather than the real implementation. That's a distinct issue from this link fix and I'm opening it separately rather than folding it into this PR.