### PR TITLE
fix(device-table): reject oversized entry counts

### DIFF
--- a/core/device_table.c
+++ b/core/device_table.c
@@ -75,6 +75,8 @@ int eos_device_table_validate(const eos_device_table_t *table)
     if (!table) return EOS_ERR_INVALID;
     if (table->magic != EOS_DEVTABLE_MAGIC) return EOS_ERR_INVALID;
     if (table->version != EOS_DEVTABLE_VERSION) return EOS_ERR_VERSION;
+    if (table->mem_region_count > EOS_MAX_MEM_REGIONS) return EOS_ERR_INVALID;
+    if (table->periph_count > EOS_MAX_PERIPHERALS) return EOS_ERR_INVALID;
 
     uint32_t expected = compute_table_crc(table);
     if (table->crc32 != expected) return EOS_ERR_CRC;

--- a/tests/unit/test_device_table.c
+++ b/tests/unit/test_device_table.c
@@ -116,6 +116,22 @@ TEST(test_corrupt_crc_fails)
     ASSERT(eos_device_table_validate(&table) == EOS_ERR_CRC);
 }
 
+TEST(test_oversized_counts_fail)
+{
+    eos_device_table_t table;
+    eos_device_table_init(&table, "Oversized");
+    table.mem_region_count = EOS_MAX_MEM_REGIONS + 1;
+    eos_device_table_finalize(&table);
+
+    ASSERT(eos_device_table_validate(&table) == EOS_ERR_INVALID);
+
+    table.mem_region_count = 0;
+    table.periph_count = EOS_MAX_PERIPHERALS + 1;
+    eos_device_table_finalize(&table);
+
+    ASSERT(eos_device_table_validate(&table) == EOS_ERR_INVALID);
+}
+
 int main(void)
 {
     printf("=== eBootloader: Device Table Unit Tests ===\n\n");
@@ -127,8 +143,9 @@ int main(void)
     run_test_memory_overflow();
     run_test_finalize_and_validate();
     run_test_corrupt_crc_fails();
+    run_test_oversized_counts_fail();
 
-    tests_run = 7;
+    tests_run = 8;
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Reject device tables whose declared memory-region or peripheral counts exceed their fixed array capacities.

## Problem

`eos_device_table_validate()` previously checked the table magic, version, and CRC, but did not validate `mem_region_count` or `periph_count`.

A malformed device table could therefore have a valid CRC while declaring more entries than its fixed arrays can store.

Code that trusts a successful validation result could then iterate past the bounds of the memory-region or peripheral arrays.

## Solution

Add structural validation for both count fields before accepting the table:

- Reject `mem_region_count > EOS_MAX_MEM_REGIONS`
- Reject `periph_count > EOS_MAX_PERIPHERALS`
- Return the existing `EOS_ERR_INVALID` error for invalid structural metadata

Valid device tables and the public API remain unchanged.

## Testing

- Added regression coverage for oversized memory-region counts.
- Added regression coverage for oversized peripheral counts.
- Confirmed the regression failed before the production fix.
- `test_device_table`: 8/8 passed after the fix.
- ASan/UBSan targeted tests: 8/8 passed.
- Unaffected CTest suite: 13/13 passed.
- Full CTest: 13/14 due to the existing `test_recovery` link failure on upstream.
- Config generation passed using the repository CI fixture.
- `git diff --check` passed.
- Independent review completed with no findings.

## Impact / Limitations

This is a focused device-table validation fix with no API changes or new dependencies.

The existing unrelated `test_recovery` link failure and pre-existing compiler warnings are not addressed by this PR.