### PR TITLE
fix(eboot): stop a failed flash read from passing the integrity check

### DIFF
--- a/core/image_verify.c
+++ b/core/image_verify.c
@@ -30,8 +30,11 @@ static uint32_t crc32_byte(uint32_t crc, uint8_t byte)
     return crc;
 }
 
-uint32_t eos_crc32(uint32_t addr, size_t len)
+int eos_crc32(uint32_t addr, size_t len, uint32_t *out)
 {
+    if (!out)
+        return EOS_ERR_INVALID;
+
     uint32_t crc = 0xFFFFFFFF;
     uint8_t buf[256];
 
@@ -39,7 +42,7 @@ uint32_t eos_crc32(uint32_t addr, size_t len)
         size_t chunk = (len > sizeof(buf)) ? sizeof(buf) : len;
 
         if (eos_hal_flash_read(addr, buf, chunk) != EOS_OK)
-            return 0;
+            return EOS_ERR_FLASH;
 
         for (size_t i = 0; i < chunk; i++) {
             crc = crc32_byte(crc, buf[i]);
@@ -49,7 +52,8 @@ uint32_t eos_crc32(uint32_t addr, size_t len)
         len -= chunk;
     }
 
-    return ~crc;
+    *out = ~crc;
+    return EOS_OK;
 }
 
 int eos_image_parse_header(uint32_t addr, eos_image_header_t *out)
@@ -102,8 +106,13 @@ int eos_image_verify_integrity(const eos_image_header_t *hdr, uint32_t addr)
         return EOS_OK;
     }
 
-    /* CRC32 fallback */
-    uint32_t computed_crc = eos_crc32(payload_addr, hdr->image_size);
+    /* CRC32 fallback. A failed read must not be mistaken for a CRC of zero:
+     * an image whose stored CRC is zero and whose payload runs past the end
+     * of the device would otherwise verify clean without a byte being read. */
+    uint32_t computed_crc;
+    int rc = eos_crc32(payload_addr, hdr->image_size, &computed_crc);
+    if (rc != EOS_OK)
+        return rc;
 
     uint32_t stored_crc;
     memcpy(&stored_crc, hdr->hash, sizeof(stored_crc));

--- a/include/eos_image.h
+++ b/include/eos_image.h
@@ -54,7 +54,8 @@ int eos_image_parse_header(uint32_t addr, eos_image_header_t *out);
  * @brief Verify image integrity using CRC32 or hash.
  * @param hdr   Parsed image header.
  * @param addr  Flash address of the image payload (after header).
- * @return EOS_OK if integrity check passes, EOS_ERR_CRC on failure.
+ * @return EOS_OK if integrity check passes, EOS_ERR_CRC on hash or CRC
+ *         mismatch, EOS_ERR_FLASH if the payload could not be read.
  */
 int eos_image_verify_integrity(const eos_image_header_t *hdr, uint32_t addr);
 
@@ -74,12 +75,19 @@ int eos_image_verify_signature(const eos_image_header_t *hdr);
 int eos_image_check_version(uint32_t candidate_version, uint32_t min_version);
 
 /**
- * @brief Compute CRC32 over a memory region.
+ * @brief Compute CRC32 over a flash region.
+ *
+ * Reports read failures separately from the computed value. A CRC returned
+ * in-band cannot do this: every 32-bit value is a legal CRC, so there is no
+ * value left over to mean "the read failed".
+ *
  * @param addr  Start address.
  * @param len   Length in bytes.
- * @return CRC32 value.
+ * @param out   Receives the CRC32 value on success; untouched on failure.
+ * @return EOS_OK on success, EOS_ERR_FLASH if the region could not be read,
+ *         EOS_ERR_INVALID if @p out is NULL.
  */
-uint32_t eos_crc32(uint32_t addr, size_t len);
+int eos_crc32(uint32_t addr, size_t len, uint32_t *out);
 
 #ifdef __cplusplus
 }

--- a/tests/unit/test_image_verify.c
+++ b/tests/unit/test_image_verify.c
@@ -160,6 +160,78 @@ TEST(test_parse_load_plus_size_overflow)
     ASSERT(eos_image_parse_header(0x1000, &out) == EOS_ERR_INVALID);
 }
 
+/* Independent CRC32 reference, so the positive control does not simply
+ * round-trip the implementation under test. */
+static uint32_t ref_crc32(const uint8_t *data, size_t len)
+{
+    uint32_t crc = 0xFFFFFFFFu;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (int b = 0; b < 8; b++)
+            crc = (crc & 1u) ? ((crc >> 1) ^ 0xEDB88320u) : (crc >> 1);
+    }
+    return ~crc;
+}
+
+TEST(test_integrity_crc_read_failure_is_not_success)
+{
+    /* eos_crc32() returned 0 when the flash read failed, and 0 is also a
+     * legal CRC value. A header whose stored CRC is zero and whose payload
+     * runs past the end of the device therefore verified clean without a
+     * single payload byte being read. */
+    eos_image_header_t hdr, out;
+    fill_valid_header(&hdr);
+    hdr.flags = 0;                      /* take the CRC32 path, not SHA-256 */
+    memset(hdr.hash, 0, sizeof(hdr.hash));   /* stored_crc == 0 */
+    hdr.image_size = 0x10000;           /* payload runs off the 64 KiB device */
+    write_header(0x1000, &hdr);
+
+    /* The header itself is well-formed — this is reachable in normal flow. */
+    ASSERT(eos_image_parse_header(0x1000, &out) == EOS_OK);
+
+    ASSERT(eos_image_verify_integrity(&out, 0x1000) != EOS_OK);
+}
+
+TEST(test_integrity_crc_matching_payload_accepted)
+{
+    /* Positive control: the fix must not reject images that are actually
+     * intact. */
+    eos_image_header_t hdr;
+    fill_valid_header(&hdr);
+    hdr.flags = 0;
+    hdr.image_size = 0x100;
+
+    uint32_t payload_addr = 0x1000 + hdr.hdr_size;
+    for (uint32_t i = 0; i < hdr.image_size; i++)
+        sim_flash[payload_addr + i] = (uint8_t)(i & 0xFF);
+
+    uint32_t expected = ref_crc32(&sim_flash[payload_addr], hdr.image_size);
+    memset(hdr.hash, 0, sizeof(hdr.hash));
+    memcpy(hdr.hash, &expected, sizeof(expected));
+    write_header(0x1000, &hdr);
+
+    ASSERT(eos_image_verify_integrity(&hdr, 0x1000) == EOS_OK);
+}
+
+TEST(test_integrity_crc_mismatch_rejected)
+{
+    eos_image_header_t hdr;
+    fill_valid_header(&hdr);
+    hdr.flags = 0;
+    hdr.image_size = 0x100;
+
+    uint32_t payload_addr = 0x1000 + hdr.hdr_size;
+    for (uint32_t i = 0; i < hdr.image_size; i++)
+        sim_flash[payload_addr + i] = (uint8_t)(i & 0xFF);
+
+    uint32_t wrong = ref_crc32(&sim_flash[payload_addr], hdr.image_size) ^ 0xFFFFu;
+    memset(hdr.hash, 0, sizeof(hdr.hash));
+    memcpy(hdr.hash, &wrong, sizeof(wrong));
+    write_header(0x1000, &hdr);
+
+    ASSERT(eos_image_verify_integrity(&hdr, 0x1000) == EOS_ERR_CRC);
+}
+
 int main(void)
 {
     printf("=== eBootloader: Image Header Parse Tests ===\n\n");
@@ -168,7 +240,10 @@ int main(void)
     run_test_parse_bad_magic();
     run_test_parse_entry_outside_image();
     run_test_parse_load_plus_size_overflow();
-    tests_run = 5;
+    run_test_integrity_crc_read_failure_is_not_success();
+    run_test_integrity_crc_matching_payload_accepted();
+    run_test_integrity_crc_mismatch_rejected();
+    tests_run = 8;
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

`eos_crc32()` returned `0` when the flash read failed. Zero is also a
perfectly legal CRC value, so the caller could not tell a failed read from a
successful one.

One particular image header turns that into an integrity check that passes
without a single payload byte being read.

## What is wrong

```c
uint32_t eos_crc32(uint32_t addr, size_t len)
{
    ...
        if (eos_hal_flash_read(addr, buf, chunk) != EOS_OK)
            return 0;              /* an error, but 0 is a valid CRC */
    ...
}
```

`eos_image_verify_integrity()` takes the stored CRC from the first four bytes
of `hdr->hash` and compares:

```c
uint32_t computed_crc = eos_crc32(payload_addr, hdr->image_size);
uint32_t stored_crc;
memcpy(&stored_crc, hdr->hash, sizeof(stored_crc));
if (computed_crc != stored_crc)
    return EOS_ERR_CRC;
return EOS_OK;
```

So a header with all three of these verifies clean:

- `hash[0..3] = 00 00 00 00`
- `flags` without `EOS_IMG_FLAG_HASH_SHA256`, selecting the CRC32 path
- `image_size` large enough that the payload runs past the end of the device

```
   image header (attacker controlled)        device: 64 KiB
   ┌──────────────────────────────┐          ┌────────────────────┐
   │ hash[0..3] = 00 00 00 00     │          │ 0x0000             │
   │ flags      = no SHA256 bit   │          │   ...              │
   │ image_size = 0x10000         │          │ 0xFFFF   end       │
   └──────────────────────────────┘          └────────────────────┘
                  │                                    ▲
                  └── payload at 0x109C ───────────────┘ runs off the end

   step 1   eos_hal_flash_read() fails partway
   step 2   eos_crc32() gives up and returns 0
   step 3   stored_crc is also 0
   step 4   0 == 0            ────►   EOS_OK

   Result: the image is declared intact. Nothing was verified.
```

`eos_image_parse_header()` caps `image_size` at 16 MiB but never checks it
against the actual device size, so this is reachable through the ordinary
parse then verify flow rather than needing a hand-built header. The same
happens whenever `eos_hal_get_ops()` is NULL.

Four call sites trust the result: `core/slot_manager.c:40`,
`stage1/jump_app.c:36`, `core/recovery.c:312`, `core/secure_boot.c:91`.

Worth noting that the SHA-256 branch immediately above is correct. It
propagates read errors through `eos_crypto_verify_image()`. Only the CRC32
fallback was affected.

## Why it matters

This is the integrity check a bootloader runs before jumping into an image.
Silently passing it is the worst possible failure mode: not a crash, not a
refusal to boot, but a confident "this image is fine".

It also cannot be fixed while keeping the current signature, which is why
this PR changes one. Every 32-bit value is a legal CRC, so there is no value
left over to mean "the read failed". An in-band error return is not merely
awkward here, it is impossible.

## How it is fixed

The function gains a real error channel:

```c
int eos_crc32(uint32_t addr, size_t len, uint32_t *out);
```

```
   before                                after
   ──────                                ─────
   read fails  ──►  return 0             read fails  ──►  return EOS_ERR_FLASH
   read ok     ──►  return crc           read ok     ──►  *out = crc
                                                          return EOS_OK
                    ▲                                     ▲
                    └── indistinguishable                 └── caller must
                        from a real CRC of 0                  check the status
```

`eos_image_verify_integrity()` propagates `EOS_ERR_FLASH`. All four callers
already test `rc != EOS_OK`, so their behaviour is unchanged, and
`jump_app.c` now gets a more specific code to write into the boot log than a
generic CRC mismatch.

On the signature change: `eos_crc32` is declared in the public
`include/eos_image.h`, but `core/image_verify.c` is its only caller anywhere
in the tree. I grepped `core/`, `stage0/`, `stage1/`, `hal/`, `tools/`,
`scripts/` and `tests/`. Note that `docs/book/book.md` documents a completely
different signature, `eos_crc32(const uint8_t *data, size_t len)`, so the
docs were already out of step. I left that alone rather than widen the diff.

## Testing

Three tests added to `tests/unit/test_image_verify.c`, already a registered
CTest target. It already provides a 64 KiB simulated flash whose
`sim_flash_read` fails when `addr + len > SIM_FLASH_SIZE`, which is exactly
the trigger, so no new fixture was needed.

```
$ cmake -B build -DEBLDR_BUILD_TESTS=ON -DEBLDR_BOARD=none
$ cmake --build build --parallel
$ ./build/tests/test_image_verify

  test_parse_valid_header                            [PASS]
  test_parse_null_out                                [PASS]
  test_parse_bad_magic                               [PASS]
  test_parse_entry_outside_image                     [PASS]
  test_parse_load_plus_size_overflow                 [PASS]
  test_integrity_crc_read_failure_is_not_success     [PASS]
  test_integrity_crc_matching_payload_accepted       [PASS]
  test_integrity_crc_mismatch_rejected               [PASS]

8/8 tests passed
```

Then, per `TESTING.md`, I reverted `core/image_verify.c` and
`include/eos_image.h` while keeping the tests, and rebuilt:

```
  test_integrity_crc_read_failure_is_not_success     [FAIL]
  test_image_verify.c:192: eos_image_verify_integrity(&out, 0x1000) != EOS_OK
```

The other two are deliberate controls rather than regression tests. A
matching CRC must still be accepted and a mismatched one must still be
rejected, so they pass either way. They exist to prove the fix is not
over-broad, and I would rather label them honestly than claim three
regressions where there is one.

Full suite: **13 of 14 CTest targets pass.** No new compiler warnings under
the project's `-Wall -Wextra`.

## Limitations, and things I noticed but left alone

**`test_recovery` does not build, on `master` as well as on this branch.**
`core/recovery.c` references `eos_boot_log_append`, `eos_boot_log_read` and
`eos_boot_log_get_head`, which live in `stage1/boot_log.c` and therefore in
`eboot_stage1`, but `test_recovery` links only `eboot_core`. That makes
`cmake --build build` exit non-zero today, so the `test-host` job in
`.github/workflows/build.yml` is red before this PR and stays red after it. I
verified this on a clean `master` checkout. Flagging it so this PR is not
blamed for the failing check. Happy to send a separate fix.

**I did not run the ARM cross-compile or the QEMU job.** The change is
portable C with no arch-specific content, but I verified only the host build,
using gcc 9.4 and CMake 3.16 on Ubuntu.

**The signing tools disagree with the header constants.** Separately from
this bug, `tools/eos_sign.py` writes `sig_type = 1` for Ed25519 while
`include/eos_types.h` defines `EOS_SIG_ED25519 = 3` (1 is `EOS_SIG_CRC32`),
and sets `flags = 1<<2` where `EOS_IMG_FLAG_SIGNED` is `1<<5`. It also never
sets `EOS_IMG_FLAG_HASH_SHA256`, so images it produces take the CRC32 path
and compare a CRC against the first four bytes of a SHA-256 digest.
`tools/sign_image.py --method sha256` misses the same flag, though its
`sign_ed25519` path sets it correctly. I have not touched any of this. It
wants its own PR with its own tests.

**The signature covers only `hdr->hash`.** `flags`, `image_size`,
`load_addr` and `entry_addr` are not bound by the Ed25519 signature, so
clearing the SHA-256 flag on a signed image downgrades integrity to a 4-byte
CRC while the signature still verifies. That is a design question rather than
a bug fix and is well outside this PR, but it is the reason I think the CRC32
fallback deserves a closer look in general.

## Pre-submission checklist

- [x] Builds without new warnings (`-Wall -Wextra`)
- [x] Existing tests still pass (13/14; the 14th is the pre-existing break above)
- [x] New tests added, and the regression test confirmed to fail without the change
- [x] Doxygen comments updated on both changed declarations
- [x] Commit signed off (DCO)
