### PR TITLE
test(build): restore the fw_transport suite registration dropped by #50

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,17 +62,34 @@ python scripts/generate_config.py configs/example_boot.yaml /tmp/generated/
 
 ## Test Suites
 
-eboot includes 7 unit test suites that run natively on the host:
+eboot includes 17 C unit test suites that run natively on the host, plus a
+set of Python tests that check the build files and tooling statically:
 
 | Test | Covers |
 |---|---|
 | `test_bootctl` | Boot control block save/load, CRC, rollback |
 | `test_crypto` | SHA-256 against known vectors |
+| `test_image_verify` | Image header parse bounds |
+| `test_recovery` | Recovery-mode UART protocol handler |
+| `test_slot_size_bounds` | `verify_slot()` rejects `image_size` larger than the slot |
+| `test_fw_transport` | UART raw / XMODEM / YMODEM firmware transport framing |
 | `test_device_table` | Device table create, add, validate |
 | `test_runtime_svc` | Runtime variable get/set/delete |
 | `test_board_config` | Pin/memory/IRQ config lookup |
 | `test_multicore` | Core state management, SMP/AMP init |
 | `test_board_registry` | Board register, find, activate |
+| `test_slot_manager` | Production firmware slot manager |
+| `test_boot_log` | Boot log subsystem |
+| `test_ed25519` | Ed25519 signature verification (RFC 8032) |
+| `test_keystore` | Boot keystore management |
+| `test_rollback` | Anti-rollback security counter |
+| `test_storage` | Unified storage bounds checking |
+
+Every `tests/unit/test_*.c` suite must be registered in `tests/CMakeLists.txt`
+with both an `add_executable()` and an `add_test()`. A suite that is not
+registered is never compiled and never run, and nothing else in the build
+reports it as missing, so `tests/unit/test_cmake_test_registration.py` checks
+this and fails if a suite is left out.
 
 Run all tests:
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,11 @@ add_executable(test_recovery unit/test_recovery.c)
 target_link_libraries(test_recovery PRIVATE eboot_core eboot_stage1)
 add_test(NAME test_recovery COMMAND test_recovery)
 
+# --- test_fw_transport: UART raw/XMODEM/YMODEM firmware transport ---
+add_executable(test_fw_transport unit/test_fw_transport.c)
+target_link_libraries(test_fw_transport PRIVATE eboot_core)
+add_test(NAME test_fw_transport COMMAND test_fw_transport)
+
 # --- test_slot_size_bounds: verify_slot() must reject image_size > slot capacity ---
 add_executable(test_slot_size_bounds unit/test_slot_size_bounds.c)
 target_link_libraries(test_slot_size_bounds PRIVATE eboot_core)
@@ -89,7 +94,7 @@ if(VALGRIND)
                       test_device_table test_runtime_svc test_board_config
                       test_multicore test_board_registry test_slot_manager
                       test_boot_log test_image_verify test_recovery
-                      test_slot_size_bounds)
+                      test_slot_size_bounds test_fw_transport)
         add_test(
             NAME valgrind_${TEST_NAME}
             COMMAND ${VALGRIND} ${VALGRIND_OPTS} $<TARGET_FILE:${TEST_NAME}>

--- a/tests/unit/test_cmake_test_registration.py
+++ b/tests/unit/test_cmake_test_registration.py
@@ -1,0 +1,74 @@
+"""Regression tests for the CTest registrations in tests/CMakeLists.txt.
+
+Every C suite under tests/unit/ has to be named in tests/CMakeLists.txt to be
+compiled and run at all. Nothing else notices when one is left out: the suite
+stops building, ctest reports one fewer test, and the run still goes green.
+
+That is how test_fw_transport.c -- the 12-case regression suite covering the
+unbounded raw length prefix, the unbounded YMODEM block-0 filename scan and
+the missing block-number validation -- stopped running. A merge replaced its
+registration block instead of appending a new one, so the file stayed in the
+tree while the target that built it disappeared.
+
+These parse tests/CMakeLists.txt statically, so no cmake or compiler is needed.
+"""
+
+import re
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+CMAKELISTS = TESTS_DIR.parent / "CMakeLists.txt"
+
+ADD_EXECUTABLE_RE = re.compile(r"add_executable\(\s*(\w+)\s+([^)]*?)\)", re.S)
+ADD_TEST_RE = re.compile(r"add_test\(\s*NAME\s+(\w+)\s+COMMAND\s+(\w+)")
+
+
+def _cmake_text():
+    return CMAKELISTS.read_text(encoding="utf-8")
+
+
+def _c_suites():
+    """Every C suite file under tests/unit/, by file name."""
+    return sorted(p.name for p in TESTS_DIR.glob("test_*.c"))
+
+
+def _registered_sources():
+    """Source file names named by an add_executable() in tests/CMakeLists.txt."""
+    sources = set()
+    for _target, source_list in ADD_EXECUTABLE_RE.findall(_cmake_text()):
+        for source in source_list.split():
+            sources.add(Path(source).name)
+    return sources
+
+
+def test_every_c_suite_is_built():
+    suites = _c_suites()
+    assert suites, "expected to find test_*.c suites in tests/unit/"
+
+    registered = _registered_sources()
+    missing = [name for name in suites if name not in registered]
+
+    assert not missing, (
+        "these suites exist under tests/unit/ but no add_executable() in "
+        f"tests/CMakeLists.txt builds them, so they never run: {missing}"
+    )
+
+
+def test_every_built_suite_is_registered_with_ctest():
+    text = _cmake_text()
+    targets = {target for target, _sources in ADD_EXECUTABLE_RE.findall(text)}
+    commands = {command for _name, command in ADD_TEST_RE.findall(text)}
+
+    unregistered = sorted(targets - commands)
+    assert not unregistered, (
+        "these test executables are built but never added to ctest, so a "
+        f"failure in them cannot fail the build: {unregistered}"
+    )
+
+
+def test_fw_transport_suite_is_registered():
+    """Pin the specific suite that was dropped, by name."""
+    assert "test_fw_transport.c" in _registered_sources(), (
+        "test_fw_transport.c is not built by tests/CMakeLists.txt -- the UART "
+        "transport regression suite would silently stop running again"
+    )


### PR DESCRIPTION
## Summary

`tests/unit/test_fw_transport.c` has not been compiled or run since commit
39b0925 (28 Aug). It is still in the tree, and it still passes — nothing builds it.

The merge that landed `test_slot_size_bounds` (#50) **replaced** the
`test_fw_transport` registration block in `tests/CMakeLists.txt` instead of
appending a new one, in both the `add_executable`/`add_test` section and the
valgrind target list:

```diff
-# --- test_fw_transport: UART raw/YMODEM firmware transport ---
-add_executable(test_fw_transport unit/test_fw_transport.c)
-target_link_libraries(test_fw_transport PRIVATE eboot_core)
-add_test(NAME test_fw_transport COMMAND test_fw_transport)
+# --- test_slot_size_bounds: ...
```

Nothing reports this. The build stays green, and `ctest` simply runs one fewer
test than it did the day before.

The orphaned suite is the 12-case regression set added by #51 for the UART
firmware-update transports. It covers, specifically:

- the 4-byte raw length prefix being used unchecked, so a declared length of
  `0xFFFFFFFF` drove a multi-gigabyte receive loop;
- the unbounded `strlen()` over YMODEM block 0, which ran off the end of the
  1026-byte block buffer on the STX path (the test picks fill byte `0x21`
  deliberately: its CRC over 1024 bytes is `0xE940`, so neither CRC byte is NUL
  either and nothing stopped the old scan);
- the block number being read but never validated, so a block the sender
  retransmits after a lost ACK was written to flash twice, shifting every
  following byte of the image.

Those are the fixes that have been sitting unguarded.

## Type of Change

- [x] **test** — Add or fix tests
- [x] **build** — Build system change
- [x] **docs** — Documentation

## Changes

- `tests/CMakeLists.txt`: restore the `test_fw_transport` registration, and add
  it back to the valgrind target list. `test_slot_size_bounds` is untouched —
  both are registered now.
- `tests/unit/test_cmake_test_registration.py`: new guard. It parses
  `tests/CMakeLists.txt` and fails if any `tests/unit/test_*.c` has no
  `add_executable()`, or if any test executable is built without a matching
  `add_test()`. The eBoot CI job already runs `pytest tests/`, so this catches
  the same class of drop on the PR that introduces it rather than weeks later.
- `CONTRIBUTING.md`: the test table said "7 unit test suites" and listed 7.
  There are 17. Updated, and the registration requirement is now written down.

## Testing

- [x] Unit tests pass
- [x] New tests added

**`test_fw_transport`, 12/12 pass against current `core/fw_transport_uart.c`:**

```
=== eBootloader: Firmware Transport Unit Tests ===

  test_ymodem_valid_transfer_is_written                    [OK]
  test_ymodem_duplicate_block_is_not_written_twice         [OK]
  test_ymodem_out_of_sequence_block_is_nakd                [OK]
  test_ymodem_bad_block_complement_is_nakd                 [OK]
  test_ymodem_header_without_nul_is_bounded                [OK]
  test_ymodem_stx_header_without_nul_is_bounded            [OK]
  test_ymodem_stx_duplicate_block_is_not_written_twice     [OK]
  test_ymodem_header_size_overflow_is_rejected             [OK]
  test_ymodem_first_block_must_be_zero                     [OK]
  test_raw_valid_transfer_is_written                       [OK]
  test_raw_oversized_length_is_rejected                    [OK]
  test_raw_zero_length_is_rejected                         [OK]

12/12 tests passed
```

**The guard was broken and watched to fail** (`TESTING.md`: "break the code and
watch the test fail"). Reverting only `tests/CMakeLists.txt`:

```
E   AssertionError: these suites exist under tests/unit/ but no add_executable()
    in tests/CMakeLists.txt builds them, so they never run: ['test_fw_transport.c']
2 failed, 1 passed
```

and with the registration restored, `3 passed`.

## Additional Notes / Limitations

**CI on this PR will be red, for reasons that predate it.** `eboot_core` does
not compile on master right now — `core/recovery.c` has a duplicated
`slot_size` declaration, `core/image_verify.c`'s `eos_crc32` definition
disagrees with its prototype in `eos_image.h`, and `core/ed25519_verify.c` has a
duplicated SHA-512 block with the verification tail missing — all unresolved
merge conflicts. #55, #57 and #58 are open against exactly that.

To run the restored suite I built `test_fw_transport.c` against
`fw_transport_uart.c`, `fw_update.c`, `hal_core.c` and the rest of its actual
dependencies with a local stub for `eos_ed25519_verify` (which the transport
path never calls — these images carry `sig_type = 0`). That stub is **not** part
of this branch; the diff here is three files. Once any of the build-fix PRs
lands, this suite will run under `ctest` normally, and I am happy to rebase.

Two further things I noticed and deliberately left alone, since fixing them here
would collide with the open build-fix PRs:

- `CMakeLists.txt` lists `core/boot_log.c` twice in the `eboot_core` source list
  (lines 83 and 87). CMake de-duplicates, so it is harmless — just untidy.
- `tests/unit/test_slot_manager.c` and `tests/unit/test_boot_log.c` do not
  compile independently of `eboot_core`'s breakage; that is already tracked in
  the issue titled "Two test files broken independently of eboot_core's build".
