### PR TITLE
Fix eos_crc32 signature mismatch and duplicate variable in recovery write path

### DIFF
--- a/core/recovery.c
+++ b/core/recovery.c
@@ -284,7 +284,6 @@ static int recovery_handle_write(eos_slot_t slot, uint32_t offset, uint16_t len)
     /* offset/len come straight from the wire; without this check a
      * recovery client can write past the slot boundary into the other
      * slot, boot-control blocks, or the boot log. */
-    uint32_t slot_size = eos_hal_slot_size(slot);
     if (slot_size == 0 || (uint64_t)offset + len > (uint64_t)slot_size)
         return recovery_send_nack();
 

--- a/include/eos_image.h
+++ b/include/eos_image.h
@@ -146,7 +146,7 @@ int eos_crc32_checked(uint32_t addr, size_t len, uint32_t *out_crc);
  * @param len   Length in bytes.
  * @return CRC32 value, or 0 if the region could not be read.
  */
-int eos_crc32(uint32_t addr, size_t len, uint32_t *out);
+uint32_t eos_crc32(uint32_t addr, size_t len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Problem
Two independent bugs currently block the eBoot host build
(cmake -DEBLDR_BUILD_TESTS=ON) from compiling:

1. include/eos_image.h declared eos_crc32() as
   `int eos_crc32(uint32_t addr, size_t len, uint32_t *out);`
   but this disagreed with both the function's own doc comment
   just above it (which describes a 2-argument function that
   returns the CRC32 value directly) and the actual implementation
   in core/image_verify.c (`uint32_t eos_crc32(uint32_t addr,
   size_t len)`). No caller anywhere in the codebase uses the
   3-argument form — this was a stale/copy-pasted prototype from
   the sibling function eos_crc32_checked().

2. core/recovery.c's recovery_handle_write() declared
   `uint32_t slot_size = eos_hal_slot_size(slot);` twice in the
   same function — once near the top, and again immediately before
   a later bounds-check comment (apparently left over from when
   that bounds check was added). The redeclaration is a compile
   error under MSVC (and a redundant no-op under GCC).

## Approach
- Corrected the eos_crc32 prototype in eos_image.h to match its
  own documentation and the real implementation.
- Removed the duplicate slot_size declaration in recovery.c,
  keeping the existing one and its later use in the bounds check
  unchanged.

## Testing
Built with MSVC (Visual Studio 2026 Build Tools, cmake -B build_test
-DEBLDR_BUILD_TESTS=ON) and confirmed both core/image_verify.c and
core/recovery.c compile with zero errors and zero warnings.

## Limitations / additional considerations
While verifying the fix, I found a separate, unrelated, pre-existing
bug in core/ed25519_verify.c: eos_ed25519_verify() contains what
appears to be leftover code from an incomplete merge — a duplicate,
inconsistent "compute k" block (referencing types/functions like
sha512_ctx_t and sc_reduce that don't exist elsewhere in the file),
and the function's actual signature-verification comparison (the
`diff` variable it returns) is never computed. Checking git blame,
this has been present since the file was first added, so there's no
earlier working version to restore. I did not attempt to fix this as
part of this PR: this is the codebase's signature-verification logic
for trusted boot, and a mistaken "fix" here would be far worse than
a build error, since incorrect signature verification can silently
accept unauthorized firmware. This deserves focused review by
someone who can verify the cryptographic correctness of the fix,
rather than a quick patch.