### PR TITLE
security: harden application slot boundary validation

### DIFF
--- a/stage1/jump_app.c
+++ b/stage1/jump_app.c
@@ -31,6 +31,16 @@ int eboot_jump_to_app(eos_bootctl_t *bctl, eos_slot_t slot)
     if (rc != EOS_OK)
         return rc;
 
+    /* Defense-in-depth: ensure the image fits within the actual slot
+     * before any integrity verification can stream payload bytes. */
+    uint32_t slot_size = eos_hal_slot_size(slot);
+    if (slot_size == 0 ||
+        hdr.hdr_size > slot_size ||
+        hdr.image_size > slot_size - hdr.hdr_size) {
+        eos_boot_log_append(EOS_LOG_IMAGE_INVALID, slot, EOS_ERR_INVALID);
+        return EOS_ERR_INVALID;
+    }
+
     /* Verify image integrity before jumping */
     /* eos_image_verify_integrity() adds hdr_size internally — pass base addr only */
     rc = eos_image_verify_integrity(&hdr, addr);


### PR DESCRIPTION
## Summary

Harden the Stage-1 application handoff by validating the image size against the actual slot capacity before integrity verification.

## Security impact

`eboot_jump_to_app()` previously proceeded from header parsing directly to payload integrity verification.

This change adds defense-in-depth validation before any payload bytes can be streamed:

* Rejects an invalid or unavailable slot size.
* Rejects headers larger than the physical slot.
* Rejects images whose declared payload exceeds the remaining slot capacity.
* Logs the image as invalid.
* Prevents integrity verification from reading beyond the application slot boundary.

## Validation

* `cmake --build build` — passed
* `ctest --test-dir build --output-on-failure` — **18/18 tests passed**
* `git diff --check` — passed
* Existing `test_slot_size_bounds` regression test passes.

The change is intentionally small and localized to the Stage-1 application handoff path.
