### PR TITLE
fix(tests): restore the line continuation that unterminates TEST() in test_image_verify

### DIFF
--- a/tests/unit/test_image_verify.c
+++ b/tests/unit/test_image_verify.c
@@ -91,7 +91,7 @@ static int tests_passed = 0;
     static void name(void); \
     static void run_##name(void) { \
         memset(sim_flash, 0xFF, sizeof(sim_flash)); \
-        sim_unreadable_from = UINT32_MAX;
+        sim_unreadable_from = UINT32_MAX; \
         sim_tick = 0; \
         eos_hal_init(&sim_ops); \
         printf("  %-50s ", #name); \


### PR DESCRIPTION
`master` does not build. One backslash.

```c
#define TEST(name) \
    static void name(void); \
    static void run_##name(void) { \
        memset(sim_flash, 0xFF, sizeof(sim_flash)); \
        sim_unreadable_from = UINT32_MAX;      ← no continuation
        sim_tick = 0; \
        eos_hal_init(&sim_ops); \
        ...
```

The macro ends at that line, so everything after it — the tick reset, `eos_hal_init()`, the `printf`, the call, the closing brace — is parsed as file-scope code rather than macro body. The 24 errors that fall out all point somewhere other than the cause:

```
error: redefinition of 'sim_tick' with a different type: 'int' vs 'uint32_t'
error: conflicting types for 'eos_hal_init'
error: conflicting types for 'printf'
error: extraneous closing brace ('}')
error: static declaration of 'name' follows non-static declaration
```

| | before | after |
|---|---|---|
| build | **24 errors** | 0 |
| `ctest` | 13 of 19 failing | **19/19 pass** |
| `pytest tests/` | — | 30 passed |

## Worth knowing beyond the fix

Introduced by #70 (`881f00c`). Because the macro was unterminated, **every `TEST()` in that file was defined without its per-test reset** of `sim_unreadable_from` and `sim_tick` — fixture state would have leaked between cases. That never produced a wrong result only because the file has not compiled since, so the tests have not run at all.

`CI — eBoot` was already red on `master` for this before I opened anything, so this is not a regression from another in-flight PR.
