### PR TITLE
fix(core): return false on NULL bootctl validation handle

### DIFF
--- a/core/bootctl.c
+++ b/core/bootctl.c
@@ -38,6 +38,9 @@ static void bootctl_update_crc(eos_bootctl_t *bctl)
 
 bool eos_bootctl_validate(const eos_bootctl_t *bctl)
 {
+    if (!bctl)
+        return false;
+
     if (bctl->magic != EOS_BOOTCTL_MAGIC)
         return false;
 

--- a/tests/unit/test_bootctl.c
+++ b/tests/unit/test_bootctl.c
@@ -268,6 +268,11 @@ TEST(test_version_encoding)
     ASSERT(EOS_VERSION_PATCH(v) == 65535);
 }
 
+TEST(test_validate_null)
+{
+    ASSERT(eos_bootctl_validate(NULL) == false);
+}
+
 /* ---- Main ---- */
 
 int main(void)
@@ -285,8 +290,9 @@ int main(void)
     run_test_request_recovery();
     run_test_request_factory_reset();
     run_test_version_encoding();
+    run_test_validate_null();
 
-    tests_run = 11;
+    tests_run = 12;
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;
 }


### PR DESCRIPTION
ISSUE:
In `core/bootctl.c`, `eos_bootctl_validate()` previously inspected `bctl->magic` without validating if `bctl` was non-null. Passing a `NULL` pointer to `eos_bootctl_validate()` caused an immediate null-pointer dereference crash.

APPROACH:
- Updated `eos_bootctl_validate()` in `core/bootctl.c` to add an upfront check (`if (!bctl) return false;`).
- Added `test_validate_null()` in `tests/unit/test_bootctl.c` to assert that `eos_bootctl_validate(NULL)` safely returns `false`.

TESTING & VALIDATION PERFORMED:
- Executed full test suite via `pytest`: 16/16 tests passed.
- Verified new unit test passes cleanly.

LIMITATIONS:
None.