### PR TITLE
fix(stage0): start the stack canary fill at _ebss, not _sbss

### DIFF
--- a/stage0/reset_entry.c
+++ b/stage0/reset_entry.c
@@ -56,10 +56,16 @@ void Reset_Handler(void)
     while (dst < &_ebss)
         *dst++ = 0;
 
-    /* Stack poisoning: fill remaining stack with canary pattern
-     * for post-mortem stack depth analysis and overflow detection */
+    /* Stack poisoning: fill the free RAM between the end of .bss and the
+     * current frame with a canary pattern, for post-mortem stack depth
+     * analysis and overflow detection.
+     *
+     * This starts at _ebss, not _sbss: both stage-0 linker scripts place
+     * .bss at the bottom of RAM and _estack at the top, so starting at
+     * _sbss would refill the .bss just zeroed above with 0xDEADBEEF
+     * before the first line of stage-0 runs. */
     {
-        volatile uint32_t *stack_ptr = &_sbss;
+        volatile uint32_t *stack_ptr = &_ebss;
         volatile uint32_t *stack_end = (volatile uint32_t *)(__builtin_frame_address(0));
         while (stack_ptr < stack_end - 16) {
             *stack_ptr++ = 0xDEADBEEF;

--- a/tests/unit/test_stage0_reset_entry.py
+++ b/tests/unit/test_stage0_reset_entry.py
@@ -1,0 +1,89 @@
+"""Regression tests for the stage-0 reset entry memory init.
+
+Reset_Handler zeros .bss and then fills the free RAM above it with a
+0xDEADBEEF canary for stack-depth analysis. The canary fill once started at
+_sbss instead of _ebss, so on every reset it overwrote the whole of .bss --
+including boot_log's log_head/log_initialized, board_registry's board_count
+and slot_manager's slot table -- immediately after zeroing it.
+
+stage0/ is only compiled by a cross build (CMakeLists.txt builds ebldr_stage0
+only when EBLDR_BOARD selects a board and a toolchain file is given), so this
+is a source-level guard in the style of test_cmake_board_dispatch.py: no
+cross-compiler and no target hardware are needed to run it.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RESET_ENTRY = REPO_ROOT / "stage0" / "reset_entry.c"
+STAGE0_LINKER_SCRIPTS = sorted(REPO_ROOT.glob("boards/*/*_stage0.ld"))
+
+
+def _reset_handler_body():
+    text = RESET_ENTRY.read_text(encoding="utf-8")
+    start = text.index("void Reset_Handler(void)")
+    end = text.index("\n}", start)
+    return text[start:end]
+
+
+def _strip_comments(text):
+    return re.sub(r"/\*.*?\*/", " ", text, flags=re.DOTALL)
+
+
+def test_canary_fill_starts_at_end_of_bss():
+    """The canary fill must begin at _ebss, above the .bss it just zeroed."""
+    body = _strip_comments(_reset_handler_body())
+
+    match = re.search(r"stack_ptr\s*=\s*&\s*(_\w+)", body)
+    assert match, "no canary fill pointer initialisation in Reset_Handler"
+
+    assert match.group(1) == "_ebss", (
+        f"the stack canary fill starts at {match.group(1)}; starting anywhere "
+        f"at or below _sbss overwrites the .bss zeroed a few lines above with "
+        f"0xDEADBEEF on every reset"
+    )
+
+
+def test_bss_is_zeroed_before_the_canary_fill():
+    """Order matters: zeroing after the fill would erase the canary."""
+    body = _strip_comments(_reset_handler_body())
+
+    zero_loop = body.index("while (dst < &_ebss)")
+    canary = body.index("0xDEADBEEF")
+
+    assert zero_loop < canary, (
+        "the .bss zero loop must run before the canary fill, otherwise the "
+        "canary is erased and stack-depth analysis reads all zeroes"
+    )
+
+
+def test_stage0_linker_scripts_put_the_stack_above_bss():
+    """The fix assumes .bss sits below the stack. Pin that assumption.
+
+    If a future board script inverts the layout, filling upward from _ebss
+    would run into whatever follows .bss instead of into free stack, and this
+    test is where that shows up.
+    """
+    assert STAGE0_LINKER_SCRIPTS, "no stage-0 linker scripts found"
+
+    for script in STAGE0_LINKER_SCRIPTS:
+        text = script.read_text(encoding="utf-8")
+        assert "_ebss" in text, f"{script.name} defines no _ebss"
+        assert "_estack" in text, f"{script.name} defines no _estack"
+
+        # _estack is set from the top of the RAM region, so the region name it
+        # names must be the one .bss is placed into.
+        estack = re.search(r"_estack\s*=\s*ORIGIN\((\w+)\)\s*\+\s*LENGTH\(\1\)", text)
+        assert estack, (
+            f"{script.name}: _estack is not defined as the top of a MEMORY "
+            f"region, so 'stack above .bss' can no longer be checked here"
+        )
+
+        bss_region = re.search(r"_ebss\s*=\s*\.;\s*\}\s*>\s*(\w+)", text, re.DOTALL)
+        assert bss_region, f"{script.name}: cannot find the region .bss is placed in"
+
+        assert bss_region.group(1) == estack.group(1), (
+            f"{script.name}: .bss is placed in {bss_region.group(1)} but "
+            f"_estack is the top of {estack.group(1)}"
+        )


### PR DESCRIPTION
## Summary

`Reset_Handler` zero-initializes the `.bss` section and then fills unused stack memory with the `0xDEADBEEF` canary pattern for post-mortem stack-depth analysis.

The stack-canary fill pointer was initialized to `&_sbss`, which is the beginning of `.bss`, rather than `&_ebss`, the end of `.bss`.

With the in-tree stage-0 linker layouts, `.bss` is placed below the stack. This means the canary loop can overwrite the `.bss` region that was just cleared before `ebldr_hw_init_minimal()` and `ebldr_stage0_main()` run.

This PR changes the canary fill to begin at `&_ebss`, preserving zero-initialized globals while retaining the intended stack poisoning above `.bss`.

## Type of Change

<!-- Check all that apply -->

- [ ] feat — New feature
- [x] fix — Bug fix
- [ ] docs — Documentation only
- [ ] style — Formatting, no code change
- [ ] refactor — Code restructuring without behavior change
- [x] test — Add or fix tests
- [ ] build — Build system or dependency changes
- [ ] ci — CI/CD pipeline changes
- [ ] perf — Performance improvement

## Changes

<!-- List each change made in this PR -->

- Updated `stage0/reset_entry.c` so the stack-canary fill begins at `&_ebss` instead of `&_sbss`.
- Expanded the surrounding comment to document the memory-layout assumption behind the stack fill.
- Added `tests/unit/test_stage0_reset_entry.py` as a source-level regression guard for the reset initialization sequence and stage-0 linker layout.

## Testing

<!-- How was this tested? Which test suites were run? -->

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing performed
- [x] New tests added for new functionality

Local test environment:

- WSL Ubuntu
- Python 3.10
- pytest 9.1.1
- GCC 11.4.0

New regression test:

```text
$ python -m pytest -q tests/unit/test_stage0_reset_entry.py

3 passed in 0.02s
```

Full Python test suite:

```text
$ python -m pytest -q tests/

19 passed, 1 skipped in 0.06s
```

Native host CMake build:

```bash
cmake -B build -DCMAKE_BUILD_TYPE=Release
cmake --build build --parallel
```

Result:

```text
[100%] Linking C static library libeboot_stage1.a
[100%] Built target eboot_stage1
```

The host build completed successfully.

### Regression coverage

The new source-level regression test verifies that:

1. the stack-canary fill begins at `_ebss`, rather than `_sbss`;
2. the `.bss` zeroing occurs before the canary fill;
3. the in-tree stage-0 linker scripts preserve the memory-layout assumption required by this fix.

This defect is in stage-0 reset initialization. The native host configuration uses `EBLDR_BOARD=none`, so the stage-0 reset target is not directly executed by the host build. A source-level regression test is therefore used to guard this behavior.

## Pre-Submission Checklist

- [ ] Code compiles without warnings (`-Wall -Wextra -Werror` for C)
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Documentation updated if API changed — no API change required
- [x] Commit messages follow `<type>(<scope>): <description>` convention
- [x] Branch is rebased on latest master

## Related Issues

No issue is closed by this PR.

## Screenshots / Logs

New regression test:

```text
$ python -m pytest -q tests/unit/test_stage0_reset_entry.py
3 passed in 0.02s
```

Full Python suite:

```text
$ python -m pytest -q tests/
19 passed, 1 skipped in 0.06s
```

Host build:

```text
[100%] Built target eboot_stage1
```

## Additional Notes

This is a source-level regression fix rather than a measurement performed on physical stage-0 hardware.

I have not run this change on an STM32F4 or Cortex-R5 device. The native host build also does not directly build or execute the stage-0 reset path.

The in-tree stage-0 linker scripts place `.bss` below the stack, which is the layout this fix relies on. Starting the canary fill at `_ebss` prevents the fill from overwriting zero-initialized `.bss` data while continuing to cover the unused memory above it.

The local host build produced pre-existing compiler warnings in unrelated files. In particular, `core/boot_menu.c` reported unused-parameter warnings, and `core/keystore.c` emitted the existing RFC 8032 test-key warning. The build nevertheless completed successfully, and this PR does not modify those code paths.