### PR TITLE
fix(tests): restore missing line continuation in test_image_verify TEST macro

### DIFF
--- a/tests/unit/test_image_verify.c
+++ b/tests/unit/test_image_verify.c
@@ -91,7 +91,7 @@ static int tests_passed = 0;
     static void name(void); \
     static void run_##name(void) { \
         memset(sim_flash, 0xFF, sizeof(sim_flash)); \
-        sim_unreadable_from = UINT32_MAX;
+        sim_unreadable_from = UINT32_MAX; \
         sim_tick = 0; \
         eos_hal_init(&sim_ops); \
         printf("  %-50s ", #name); \


### PR DESCRIPTION
## Issue

`master` does not build with `-DEBLDR_BUILD_TESTS=ON`:

```
tests/unit/test_image_verify.c:95:9: error: type defaults to 'int' in declaration of 'sim_tick'
tests/unit/test_image_verify.c:95:9: error: conflicting types for 'sim_tick'; have 'int'
tests/unit/test_image_verify.c:97:28: error: stray '#' in program
tests/unit/test_image_verify.c:102:17: error: conflicting types for 'name'; have 'void(void)'
... 16 errors total
```

The cause is a single missing line-continuation backslash at
`tests/unit/test_image_verify.c:94`:

```c
#define TEST(name) \
    static void name(void); \
    static void run_##name(void) { \
        memset(sim_flash, 0xFF, sizeof(sim_flash)); \
        sim_unreadable_from = UINT32_MAX;      /* <-- backslash missing */
        sim_tick = 0; \
        eos_hal_init(&sim_ops); \
        ...
```

The macro therefore ends at the `memset` line. Everything intended to
follow — the `sim_tick` reset, `eos_hal_init()`, the progress `printf`,
the call to `name()`, and the pass counter — is parsed at file scope
rather than inside `run_##name()`, which is where the cascade comes from.

The `sim_unreadable_from` reset was added in 881f00c ("fix(tlv): fail
closed on flash read errors", #70) and the backslash was dropped with it.
Because the target does not compile, `test_image_verify` is never built
and `ctest` cannot run.

## Approach

Add the backslash. One character, no behavioural change intended — the
macro body is restored to exactly what it reads as.

I looked for the same mistake elsewhere and did not find another
occurrence.

## Testing

Before:

```
$ cmake -S . -B build -DEBLDR_BUILD_TESTS=ON -DEBLDR_BOARD=none
$ cmake --build build -j8 ; echo $?
... 16 errors
1
```

After:

```
$ cmake --build build -j8 ; echo $?
0

$ ctest --test-dir build --output-on-failure
100% tests passed, 0 tests failed out of 19
Total Test time (real) = 9.79 sec
```

`test_image_verify` is test #3 in that run — it was absent before, since
the target did not build.

Python suite unaffected:

```
$ python -m pytest tests/unit tests/functional tests/performance tests/simulation -q
30 passed in 4.67s
```

## Considerations and limitations

- Verified on a host build only (`EBLDR_BOARD=none`, GCC on Windows). Not
  run under cross-compilation or on target hardware; this file is a
  host-side unit test, so I would not expect that to differ.
- No new test added. The failure is a compile error in the test file
  itself, so the existing `ctest` run is the regression signal — it goes
  from "cannot build" to 19/19.
- Worth considering separately: this landed on `master` without being
  caught, which suggests the `EBLDR_BUILD_TESTS=ON` job did not gate the
  merge. I have not investigated the workflow configuration and am not
  touching it here.

---

Status: complete. Mode: implementation.
Files changed: tests/unit/test_image_verify.c (1 line). Remotes reconfigured; master fast-forwarded to ae1e0f7.
Verification: build PASS, ctest 19/19 PASS, pytest 30 PASS — all run, output read above.
Remaining work: NOTES-eboot-review.md is stale and should be rewritten or deleted before you rely on it. You still need PRs for eBuild and eOS.
Known risks: none for this diff. The broader risk is the one that just bit us — always git fetch upstream before auditing.
Assumptions: none load-bearing; the missing backslash is visible in the source and the fix is confirmed by the compiler.
Recommended next step: branch, commit, push, open the PR. Then let me re-audit the current tree properly so you have a second, more substantial eBoot PR — the first one was worth a lot less than it looked.