### PR TITLE
fix(image): pin the whole .efw header, not four fields of it

### DIFF
--- a/include/eos_image.h
+++ b/include/eos_image.h
@@ -80,6 +80,65 @@ EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, sig_type) == 60,
 EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, signature) == 92,
                       "signature[] must stay at offset 92");
 
+/* Every remaining field, pinned.
+ *
+ * Four of the fourteen fields were asserted. Transposing two adjacent
+ * same-width fields moves neither sizeof nor any of those four offsets, so it
+ * compiled clean: with load_addr and entry_addr swapped, all four existing
+ * asserts still passed and the bootloader would load an image at its entry
+ * point and jump to its load address. A wire format needs every field pinned,
+ * not a representative sample. */
+EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, magic) == 0,
+                      "magic must stay at offset 0");
+EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, hdr_version) == 4,
+                      "hdr_version must stay at offset 4");
+EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, hdr_size) == 6,
+                      "hdr_size must stay at offset 6");
+EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, image_size) == 8,
+                      "image_size must stay at offset 8");
+EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, load_addr) == 12,
+                      "load_addr must stay at offset 12");
+EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, entry_addr) == 16,
+                      "entry_addr must stay at offset 16");
+EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, image_version) == 20,
+                      "image_version must stay at offset 20");
+EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, flags) == 24,
+                      "flags must stay at offset 24");
+EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, sig_len) == 61,
+                      "sig_len must stay at offset 61");
+EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, reserved) == 62,
+                      "reserved[] must stay at offset 62");
+
+/* Field widths. An offset assert cannot see a field growing into padding that
+ * happens to keep every later offset -- reserved[] absorbs exactly that. */
+EOS_IMG_STATIC_ASSERT(sizeof(((eos_image_header_t *)0)->hash) == 32,
+                      "hash[] is 32 bytes on the wire");
+EOS_IMG_STATIC_ASSERT(sizeof(((eos_image_header_t *)0)->reserved) == 30,
+                      "reserved[] is 30 bytes on the wire");
+EOS_IMG_STATIC_ASSERT(sizeof(((eos_image_header_t *)0)->signature) == 64,
+                      "signature[] is 64 bytes on the wire");
+
+/* Constant values. These travel inside the image, so they are wire format too
+ * and an offset assert says nothing about them. Changing EOS_SIG_ED25519 from
+ * 3 to 4, or reordering the enum, compiled cleanly and passed every assert
+ * above while making eBoot misread the signature type of every image already
+ * in the field. eFirmware pins the same numbers on its side
+ * (EFW_IMAGE_MAGIC == 0x454F5349u, EFW_SIG_ED25519 == 3); these are the
+ * matching half, so the two definitions can no longer drift apart in silence. */
+EOS_IMG_STATIC_ASSERT(EOS_IMG_MAGIC == 0x454F5349,
+                      "magic is \"EOSI\" and eFirmware stamps the same value");
+EOS_IMG_STATIC_ASSERT(EOS_HASH_SIZE == 32, "hash is SHA-256, 32 bytes");
+EOS_IMG_STATIC_ASSERT(EOS_SIG_MAX_SIZE == 64, "signature area is 64 bytes");
+EOS_IMG_STATIC_ASSERT(EOS_IMG_SIGNED_LEN == 92,
+                      "the signed prefix is the 92 bytes before signature[]");
+EOS_IMG_STATIC_ASSERT(EOS_IMAGE_HDR_VERSION == 2,
+                      "eBoot writes and expects header format v2");
+EOS_IMG_STATIC_ASSERT((int)EOS_SIG_NONE == 0, "EOS_SIG_NONE is 0 on the wire");
+EOS_IMG_STATIC_ASSERT((int)EOS_SIG_CRC32 == 1, "EOS_SIG_CRC32 is 1 on the wire");
+EOS_IMG_STATIC_ASSERT((int)EOS_SIG_SHA256 == 2, "EOS_SIG_SHA256 is 2 on the wire");
+EOS_IMG_STATIC_ASSERT((int)EOS_SIG_ED25519 == 3, "EOS_SIG_ED25519 is 3 on the wire");
+EOS_IMG_STATIC_ASSERT((int)EOS_SIG_ECDSA == 4, "EOS_SIG_ECDSA is 4 on the wire");
+
 /* ---------------- Image Validation API ---------------- */
 
 /**


### PR DESCRIPTION
Closes #66, parts 1 and 2.

`eos_image_header_t` is a wire format: eFirmware writes these bytes, eBoot reads them, and the signing tools address fields by absolute offset. Four of its fourteen fields were pinned — `sizeof`, `hash`, `sig_type`, `signature`.

## A field swap passed every existing assert

Transposing two adjacent same-width fields moves neither `sizeof` nor any of those four offsets:

```
$ # load_addr and entry_addr transposed
$ cc -std=c11 -I include -c abi_tu.c
   (on master: compiles clean, 0 asserts fire)
```

The bootloader would then load an image at its entry point and jump to its load address. With this change:

```
include/eos_image.h:99:  static assertion failed: load_addr must stay at offset 12
include/eos_image.h:101: static assertion failed: entry_addr must stay at offset 16
```

## No constant's value was pinned on this side

`EOS_IMG_MAGIC`, `EOS_HASH_SIZE`, `EOS_SIG_MAX_SIZE`, `EOS_IMG_SIGNED_LEN`, `EOS_IMAGE_HDR_VERSION` and the five `eos_sig_type_t` values all travel inside the image, so they are wire format too, and an offset assert says nothing about them.

```
$ # EOS_SIG_ED25519 = 3 -> 4
   master:    compiles clean, 0 asserts fire
   this PR:   static assertion failed: EOS_SIG_ED25519 is 3 on the wire
```

That change would make eBoot misread the signature type of every image already in the field. eFirmware pins `EFW_IMAGE_MAGIC == 0x454F5349u` and `EFW_SIG_ED25519 == 3` on its side; these are the matching half, so the two definitions can no longer drift apart in silence.

## What is added

| | count |
|---|---|
| missing field offsets | 10 |
| field widths | 3 |
| constant values | 11 |
| **total asserts** | **30** (was 4) |

The three width asserts are there because an offset assert cannot see a field growing into padding that happens to keep every later offset — `reserved[30]` absorbs exactly that.

**Header only.** No struct member, constant, or line of logic changes, so every image on disk today parses exactly as it did before. The asserts are all `EOS_IMG_STATIC_ASSERT`, which already degrades to nothing before C11.

## Validation

```
compiles clean, all 30 pass
load_addr/entry_addr transposed  ->  2 asserts fire   (master: 0)
EOS_SIG_ED25519 = 3 -> 4         ->  1 assert fires   (master: 0)
cmake -DEBLDR_BUILD_TESTS=ON + ctest  ->  20/20 passed
```

## Not touched

Part 3 of #66 — eFirmware stamping `hdr_version = 1` while eBoot supports only v2, so `core/image_verify.c` admits a v1 image at the parser and then fails it at the signature — is a security-policy call (reject at parse, branch the verifier, or change what efwtool stamps). It fails closed, so it is not an escalation, and it wants a decision rather than a patch. Deliberately left out.
