### PR TITLE
fix: run the signing suite in CI and keep the boot log head consistent on write failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,14 @@ jobs:
             cmake ninja-build gcc-12 g++-12 \
             gcc-arm-none-eabi binutils-arm-none-eabi \
             lcov gcovr python3-pip
-          pip3 install pytest pytest-cov
+          # Install from requirements.txt rather than a hand-maintained list.
+          # tests/unit/test_sign_image.py guards itself with
+          # pytest.importorskip("cryptography"), so a dependency that is
+          # declared nowhere does not fail the job -- it skips the 14 cases
+          # that pin the signed header format and the run still goes green.
+          # pytest-cov stays separate: it is a CI-only coverage plugin, not a
+          # dependency of anything in the repository.
+          pip3 install -r requirements.txt pytest-cov
 
       - name: Configure (host)
         run: |

--- a/core/boot_log.c
+++ b/core/boot_log.c
@@ -41,7 +41,15 @@ void eos_boot_log_append(uint32_t event, uint32_t slot, uint32_t detail)
     uint32_t offset = log_head * sizeof(eos_boot_log_entry_t);
     uint32_t addr   = ops->log_addr + offset;
 
-    eos_hal_flash_write(addr, &entry, sizeof(entry));
+    /* Advance the head only once the entry is actually on flash. Advancing
+     * unconditionally skips a slot that was never written, and the head is
+     * persisted in the boot control block, so the gap survives the reset:
+     * eos_boot_log_read() then hands the reader erased flash as if it were an
+     * entry, and the slot is never reused. eos_boot_log_clear() guards its own
+     * state change against a failed erase for the same reason. */
+    int rc = eos_hal_flash_write(addr, &entry, sizeof(entry));
+    if (rc != EOS_OK)
+        return;
 
     log_head = (log_head + 1) % EOS_BOOT_LOG_MAX;
 }

--- a/core/boot_menu.c
+++ b/core/boot_menu.c
@@ -12,13 +12,21 @@
 #include "eos_bootctl.h"
 #include <string.h>
 
+/* eos_hal_uart_write()/eos_hal_uart_read() are compatibility macros over the
+ * HAL's single-UART API (eos_hal_uart_send()/eos_hal_uart_recv()), so they
+ * expand without their port argument and it reads as unused under -Wextra.
+ * The parameter is kept because eos_boot_menu_config_t carries a uart_port and
+ * the board ports address one; it starts being honoured the moment the HAL
+ * grows a per-port call. */
 static void uart_puts(uint8_t port, const char *str)
 {
+    (void)port;
     eos_hal_uart_write(port, (const uint8_t *)str, strlen(str));
 }
 
 static int uart_getc(uint8_t port, uint32_t timeout_ms)
 {
+    (void)port;
     uint8_t ch;
     int rc = eos_hal_uart_read(port, &ch, 1, timeout_ms);
     return (rc == EOS_OK) ? (int)ch : -1;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyyaml>=6.0
 pytest>=9.0
 pyserial>=3.5
+cryptography>=41.0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,8 +27,12 @@ target_link_libraries(eboot_test_secure_boot PRIVATE eboot_core)
 add_test(NAME test_secure_boot COMMAND eboot_test_secure_boot)
 
 # --- test_recovery: UART recovery write range ---
+# eboot_stage1 links eboot_core PUBLIC, so naming eboot_core here too put it on
+# the link line twice -- ahead of the target that needs it, which is the wrong
+# order for a left-to-right archive scan, so CMake appended it again anyway and
+# the linker reported the duplicate. The transitive dependency covers it.
 add_executable(eboot_test_recovery unit/test_recovery.c)
-target_link_libraries(eboot_test_recovery PRIVATE eboot_core eboot_stage1)
+target_link_libraries(eboot_test_recovery PRIVATE eboot_stage1)
 add_test(NAME test_recovery COMMAND eboot_test_recovery)
 
 # --- test_fw_transport: UART raw/XMODEM/YMODEM firmware transport ---

--- a/tests/unit/test_boot_log.c
+++ b/tests/unit/test_boot_log.c
@@ -239,6 +239,43 @@ static void test_clear_reports_erase_failure(void)
     ASSERT(eos_boot_log_get_head() == 1);
 }
 
+/* The same reasoning on the write path. append() cannot report a failure --
+ * it returns void -- but it can decline to advance past a slot it never wrote.
+ * The head is persisted in the boot control block, so advancing anyway leaves
+ * a permanent hole: the slot is skipped for good and reads back as erased
+ * flash that a reader cannot tell apart from a real entry. */
+static void test_append_does_not_advance_head_when_write_fails(void)
+{
+    eos_boot_log_init(0);
+    eos_boot_log_append(EOS_LOG_BOOT_START, EOS_SLOT_A, 111);
+    ASSERT(eos_boot_log_get_head() == 1);
+
+    write_result = EOS_ERR_FLASH;
+    eos_boot_log_append(EOS_LOG_BOOT_FAIL, EOS_SLOT_A, 222);
+
+    /* Head stays put and slot 1 is still erased flash. */
+    ASSERT(eos_boot_log_get_head() == 1);
+
+    eos_boot_log_entry_t entry;
+    ASSERT(eos_boot_log_read(1, &entry) == EOS_OK);
+    ASSERT(entry.event == 0xFFFFFFFFu);
+
+    /* The next successful append reuses that slot instead of skipping it. */
+    write_result = EOS_OK;
+    eos_boot_log_append(EOS_LOG_CONFIRM, EOS_SLOT_B, 333);
+    ASSERT(eos_boot_log_get_head() == 2);
+
+    ASSERT(eos_boot_log_read(1, &entry) == EOS_OK);
+    ASSERT(entry.event == EOS_LOG_CONFIRM);
+    ASSERT(entry.slot == EOS_SLOT_B);
+    ASSERT(entry.detail == 333);
+
+    /* The entry written before the failure is untouched. */
+    ASSERT(eos_boot_log_read(0, &entry) == EOS_OK);
+    ASSERT(entry.event == EOS_LOG_BOOT_START);
+    ASSERT(entry.detail == 111);
+}
+
 static void test_entry_layout_is_stable(void)
 {
     /* The log is parsed by host tooling and by application firmware through
@@ -261,7 +298,8 @@ int main(void)
     RUN(test_read_rejects_bad_arguments);
     RUN(test_clear_erases_the_sector_and_resets_head);
     RUN(test_clear_reports_erase_failure);
+    RUN(test_append_does_not_advance_head_when_write_fails);
     RUN(test_entry_layout_is_stable);
-    printf("\n%d/10 tests passed\n", tests_passed);
+    printf("\n%d/11 tests passed\n", tests_passed);
     return 0;
 }

--- a/tests/unit/test_requirements.py
+++ b/tests/unit/test_requirements.py
@@ -1,0 +1,152 @@
+"""Regression tests for the Python dependencies the test suite needs to run.
+
+tests/unit/test_sign_image.py guards itself with
+pytest.importorskip("cryptography"). That is the right behaviour for a
+contributor who has not installed the signing tools, but it also means an
+undeclared dependency fails nothing: the 14 cases that pin the signed .efw
+header wire format are skipped and the run still reports success.
+
+cryptography is imported by tools/sign_image.py and tools/eos_sign.py, but it
+was named neither in requirements.txt nor by the CI job that runs pytest --
+that job installed a hand-written list instead of the repository requirements
+-- so those 14 tests had never executed in CI.
+
+A hand-maintained dependency list beside requirements.txt is the thing that
+goes stale, so these check that the list is the requirements file, rather than
+checking any particular package name twice over.
+
+These parse requirements.txt and the workflow files as text, in the style of
+test_cmake_test_registration.py, so no cmake, compiler, network or GitHub API
+is needed.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REQUIREMENTS = REPO_ROOT / "requirements.txt"
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+SIGN_IMAGE_SUITE = Path(__file__).resolve().parent / "test_sign_image.py"
+
+# A requirement line: the distribution name, up to any extras, version
+# specifier or environment marker.
+REQUIREMENT_NAME_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+# Job ids are the only keys at two-space indent inside a workflow's jobs: block.
+JOB_RE = re.compile(r"^  ([A-Za-z0-9_-]+):$", re.M)
+
+# `pytest tests/` or `python3 -m pytest tests/ -v ...`
+RUNS_PYTEST_RE = re.compile(r"\bpytest\b[^\n]*\btests/")
+
+# `pip install -r requirements.txt`, with or without the pip3 spelling.
+INSTALLS_REQUIREMENTS_RE = re.compile(r"\bpip3?\s+install\b[^\n]*-r\s+requirements\.txt")
+
+
+def _strip_comments(text):
+    """Drop whole-line YAML comments so prose about pytest is not mistaken
+    for a step that runs it."""
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def _declared_requirements():
+    """Distribution names declared in requirements.txt, lowercased."""
+    names = set()
+    for line in REQUIREMENTS.read_text(encoding="utf-8").splitlines():
+        line = line.split("#", 1)[0].strip()
+        if not line or line.startswith("-"):
+            continue
+        match = REQUIREMENT_NAME_RE.match(line)
+        if match:
+            names.add(match.group(1).lower())
+    return names
+
+
+def _workflow_jobs():
+    """(workflow name, job id, job text) for every job in .github/workflows."""
+    jobs = []
+    for workflow in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        text = _strip_comments(workflow.read_text(encoding="utf-8"))
+
+        start = text.find("\njobs:")
+        if start == -1:
+            continue
+        body = text[start:]
+
+        headers = list(JOB_RE.finditer(body))
+        for i, header in enumerate(headers):
+            end = headers[i + 1].start() if i + 1 < len(headers) else len(body)
+            jobs.append((workflow.name, header.group(1), body[header.start():end]))
+    return jobs
+
+
+def _importorskip_modules():
+    """Module names test_sign_image.py refuses to run without."""
+    text = SIGN_IMAGE_SUITE.read_text(encoding="utf-8")
+    return set(re.findall(r"importorskip\(\s*[\"']([A-Za-z0-9._-]+)[\"']", text))
+
+
+def test_cryptography_is_declared_in_requirements():
+    """Pin the specific dependency that was missing, by name."""
+    assert "cryptography" in _declared_requirements(), (
+        "cryptography is not declared in requirements.txt -- it is imported by "
+        "tools/sign_image.py and tools/eos_sign.py, and without it "
+        "tests/unit/test_sign_image.py skips all 14 of its cases instead of "
+        "running them"
+    )
+
+
+def test_every_importorskip_dependency_is_declared():
+    """A suite may only opt out of running for a dependency the repo declares.
+
+    Guards the general case: adding a new importorskip for some package that
+    requirements.txt never names would silently park that suite in the skipped
+    column, exactly as happened to the signing tests.
+    """
+    modules = _importorskip_modules()
+    assert modules, (
+        "expected test_sign_image.py to guard itself with "
+        "pytest.importorskip(...); if that guard is gone this test no longer "
+        "checks anything and should be updated"
+    )
+
+    declared = _declared_requirements()
+    undeclared = sorted(name for name in modules if name.lower() not in declared)
+
+    assert not undeclared, (
+        "test_sign_image.py skips itself when these modules are missing, but "
+        f"requirements.txt does not declare them, so they will never be "
+        f"installed and the suite will never run: {undeclared}"
+    )
+
+
+def test_jobs_that_run_pytest_install_the_repository_requirements():
+    """The environment the tests run in has to come from requirements.txt.
+
+    Installing a hand-written package list beside requirements.txt is what let
+    cryptography go missing: the list was complete enough for the suite to
+    collect and import, so nothing failed -- the signing cases just skipped.
+    """
+    pytest_jobs = [
+        (workflow, job, text)
+        for workflow, job, text in _workflow_jobs()
+        if RUNS_PYTEST_RE.search(text)
+    ]
+
+    assert pytest_jobs, (
+        "no workflow job appears to run pytest over tests/; if the Python "
+        "suite moved, this guard needs to move with it"
+    )
+
+    missing = [
+        f"{workflow}:{job}"
+        for workflow, job, text in pytest_jobs
+        if not INSTALLS_REQUIREMENTS_RE.search(text)
+    ]
+
+    assert not missing, (
+        "these jobs run pytest over tests/ but never install from "
+        "requirements.txt, so a declared dependency is absent at run time and "
+        f"the suites that need it skip while the job still passes: {missing}"
+    )


### PR DESCRIPTION
## Summary

Three small, independent fixes to test and build hygiene:

1. **A test suite that had never run in CI now runs.** `tests/unit/test_sign_image.py` was skipping all 14 of its cases because its dependency was declared nowhere.
2. **The boot log no longer corrupts its ring on a failed flash write.** `eos_boot_log_append()` advanced the head past a slot it never wrote.
3. **Two avoidable host build warnings are cleared**, moving toward the zero-warning standard in `CONTRIBUTING.md`.

Nothing here changes boot behaviour on a working device. The value is that failures now surface instead of passing silently.

Each item is a separate commit and can be reviewed or dropped independently.

## Context

eBoot is a two-stage bootloader: Stage-0 brings up hardware, Stage-1 scans the A/B slots, verifies an image (SHA-256 / Ed25519 / anti-rollback), and jumps to it. `core/` holds the platform-agnostic logic that builds and tests natively on the host; `boards/` and `stage0/` hold architecture-specific code that does not.

That split makes the host test suite the main safety net for `core/` — it is the only part CI can actually execute. Both substantive fixes here are about that net having a hole: one suite was not running at all, and one failure path had a fixture but no test.

## What changed

| Commit | Scope | Files |
|---|---|---|
| `b1b6c05` | `fix(ci)` — signing tests execute again | `requirements.txt`, `.github/workflows/ci.yml`, `tests/unit/test_requirements.py` |
| `dc32112` | `fix(core)` — boot log head consistency | `core/boot_log.c`, `tests/unit/test_boot_log.c` |
| `7521325` | `fix(build)` — host build warnings | `core/boot_menu.c`, `tests/CMakeLists.txt` |

7 files, +222 / −4. No changes to `secure_boot.c`, `image_verify.c`, `ed25519_verify.c`, `recovery.c`, `keystore.c`, `stage0/`, `boards/`, `jump_app.c`, or the root `CMakeLists.txt`.

---

## 1. The signing test suite was never executing in CI

### Problem

`tests/unit/test_sign_image.py` guards itself with:

```python
pytest.importorskip("cryptography", reason="signing tools require 'cryptography'")
```

`cryptography` is imported by `tools/sign_image.py` and `tools/eos_sign.py`, but was declared neither in `requirements.txt` nor by the CI job that runs pytest — that job installed a hand-written list, `pip3 install pytest pytest-cov`. Because `importorskip` degrades to a skip rather than a failure, the suite sat quietly in the skipped column and the job still reported success.

### Impact

The 14 cases that never ran are the ones pinning the v2 signed-header wire format: that the Ed25519 signature covers the whole header prefix, that `entry_addr`, `load_addr`, `image_size`, `image_version`, `sig_type` and `hdr_version` are each bound to it, that clearing `EOS_IMG_FLAG_HASH_SHA256` is rejected, and that an unsigned image fails `--verify`.

All 14 pass today — nothing is broken. The exposure is that a regression in `imgpack.py` or `sign_image.py` would have merged green.

### Fix

- Declare the dependency: `cryptography>=41.0` in `requirements.txt`, following the file's existing `name>=major.minor` convention.
- Install from the requirements file instead of a parallel list: `pip3 install -r requirements.txt pytest-cov`. `pytest-cov` stays separate because it is a CI-only coverage plugin, not a repository dependency.
- Add `tests/unit/test_requirements.py` so this cannot lapse again.

The `importorskip` guard stays — a contributor without the signing tools should still get a skip, not a hard error. The new test is what makes the skip impossible in CI.

### Regression guard

Three checks, layered specific to general, written as static text parsing in the style of `test_cmake_test_registration.py` — no cmake, compiler, network, GitHub API or YAML dependency:

1. `test_cryptography_is_declared_in_requirements` — pins the specific dependency by name.
2. `test_every_importorskip_dependency_is_declared` — cross-references every `importorskip(...)` against `requirements.txt`, so a *future* suite with an undeclared guard is caught too.
3. `test_jobs_that_run_pytest_install_the_repository_requirements` — scans every workflow, finds each job running pytest over `tests/`, and requires `-r requirements.txt`. It names the offending job in the failure message.

Both failure modes were confirmed by breaking the fix and watching the tests fail:

```text
# with cryptography removed from requirements.txt
AssertionError: test_sign_image.py skips itself when these modules are missing, but
requirements.txt does not declare them, so they will never be installed and the
suite will never run: ['cryptography']

# with the CI install line reverted
AssertionError: these jobs run pytest over tests/ but never install from
requirements.txt, so a declared dependency is absent at run time and the suites
that need it skip while the job still passes: ['ci.yml:test']
```

---

## 2. `eos_boot_log_append()` advanced the head past a slot it never wrote

### Problem

```c
eos_hal_flash_write(addr, &entry, sizeof(entry));   /* return value discarded */

log_head = (log_head + 1) % EOS_BOOT_LOG_MAX;       /* advances regardless */
```

When the write fails the head advances anyway. The slot is left as erased flash but skipped permanently.

### Impact

`log_head` is persisted in the boot control block and reloaded by `eos_boot_log_init()` on the next boot, so the gap survives the reset. `eos_boot_log_read()` then returns all-`0xFF` erased flash that a reader cannot distinguish from a real entry, and the slot is never reused. The consumers affected are `eos_fw_read_boot_log()` and the recovery log-retrieval command, both of which walk the ring from `eos_boot_log_get_head()`.

This is a diagnostics and post-mortem reliability issue — nothing in the verification chain reads the boot log; attestation is separate, in `secure_boot.c`.

### Reproduced before the fix

```text
head after failed append = 2 (expected 1: the slot was never written)
  [FAIL] eos_boot_log_get_head() == 1
slot 1 event after next successful append = 0xFFFFFFFF (expected EOS_LOG_CONFIRM=0x00000009)
  [FAIL] e.event == (uint32_t)EOS_LOG_CONFIRM
```

### Fix

Advance the head only after the write succeeds:

```c
int rc = eos_hal_flash_write(addr, &entry, sizeof(entry));
if (rc != EOS_OK)
    return;

log_head = (log_head + 1) % EOS_BOOT_LOG_MAX;
```

`eos_boot_log_append()` returns `void`, so a failure still cannot be reported to the caller — but it can decline to advance. This mirrors what `eos_boot_log_clear()` in the same file already does for a failed erase, and the reasoning documented there applies equally: reporting success would let the next boot walk over entries that are still present.

No signature change, no header change, no new API, no new error code, no change to bootctl.

### Regression test

`test_append_does_not_advance_head_when_write_fails` uses the `write_result` injection hook that already existed in the fixture but that no test had exercised. It asserts the head does not move, the target slot is still erased, the next successful append lands in *that same slot*, the head then advances normally, and the entry written before the failure is untouched.

Confirmed load-bearing by reverting the fix and rebuilding:

```text
[FAIL] tests/unit/test_boot_log.c:257: eos_boot_log_get_head() == 1
... all 9 pre-existing tests PASS
```

The pre-existing suite genuinely did not cover this path.

---

## 3. Pre-existing host build warnings

Fixed in a separate commit, because `CONTRIBUTING.md` asks for a warning-clean `-Wall -Wextra` build.

**`core/boot_menu.c`** — two `-Wunused-parameter` warnings on `port`. The cause is worth recording: `eos_hal_uart_write(port, data, len)` is a compatibility macro in `eos_hal.h` that expands to `eos_hal_uart_send(data, len)` and discards the port, because the HAL exposes only a single-UART API. Honouring the port properly would mean adding per-port HAL calls across every board port, well outside this PR. Added `(void)port;` — the idiom already used throughout `core/` — with a comment recording *why* it is ignored, so the warning goes without hiding the API gap.

**`tests/CMakeLists.txt`** — `ld: warning: ignoring duplicate libraries: '../libeboot_core.a'`. `eboot_test_recovery` named `eboot_core eboot_stage1`, but `eboot_stage1` already links `eboot_core` `PUBLIC`, and the explicit copy sat *ahead* of the target needing it — the wrong order for a left-to-right archive scan — so CMake appended it again and the linker reported the duplicate. Verified with `nm` before removing it that there is no circular dependency: `eboot_core` requires zero symbols from `eboot_stage1`, while `eboot_stage1` requires many from `eboot_core`. The transitive link covers it on GNU ld as well as ld64.

---

## Testing

### Before

CI-equivalent environment (`pip install pytest pytest-cov`, matching what `ci.yml` did), on unmodified `master`:

```text
$ python -m pytest tests/ -q -rs
SKIPPED [1] tests/unit/test_sign_image.py:26: signing tools require 'cryptography'
19 passed, 1 skipped in 0.05s
exit 0          # green, with the signing suite never executed
```

### After

Environment built the way CI now builds it (`pip install -r requirements.txt pytest-cov`):

```text
$ python -m pytest tests/ -q
36 passed in 2.72s
```

`36 = 19 pre-existing + 14 signing + 3 new guard.` Zero skips.

### Full results

| Check | Result |
|---|---|
| Release configure + build | PASS, exit 0 |
| Release `ctest --no-tests=error` | **20/20 (100%)** |
| Debug configure + build | PASS, exit 0 |
| Debug `ctest --no-tests=error` | **20/20 (100%)** |
| `pytest tests/` | **36 passed, 0 skipped** |
| `pytest tests/unit/test_sign_image.py` | **14 passed** |
| `pytest tests/unit/test_requirements.py` | **3 passed** |
| `ctest -R test_boot_log` | **11/11** (was 10/10) |
| New compiler warnings | **none** — output diffed against a build of unmodified `master` |
| Warning count | **4 before → 1 after** (the remaining one is deliberate; see below) |

Contributors without `cryptography` installed still get a clean run with a graceful skip: `22 passed, 1 skipped`.

```bash
cmake -B build -DCMAKE_BUILD_TYPE=Release -DEBLDR_BUILD_TESTS=ON -DEBLDR_BOARD=none
cmake --build build --parallel
ctest --test-dir build --output-on-failure --no-tests=error
pip install -r requirements.txt
python -m pytest tests/ -q
```

---

## Everything found, and what was done about it

This came out of a targeted review of the host-testable parts of the tree. It was not an exhaustive audit, and it deliberately did not examine the verification, recovery or key-handling paths.

### Fixed in this PR

| # | Finding | Location | Why fixed here |
|---|---|---|---|
| 1 | Signing suite skipped in CI; dependency declared nowhere | `requirements.txt`, `ci.yml` | Reproducible, tiny diff, restores 14 tests, zero behaviour change |
| 2 | Ring head advances past a slot a failed write never reached | `core/boot_log.c` | Reproduced, two-line fix, precedent already set by `eos_boot_log_clear()` |
| 3 | Two `-Wunused-parameter` warnings | `core/boot_menu.c` | Violates the project's stated zero-warning standard; local, no redesign |
| 4 | Duplicate library on the link line | `tests/CMakeLists.txt` | Same standard; verified safe via symbol analysis |

### Found and deliberately left alone

| # | Finding | Location | Why not touched |
|---|---|---|---|
| 5 | `core/fdt_loader.c` is in no CMake source list, so it is never compiled; it has no callers and no tests | `CMakeLists.txt` | #72 identified this and explicitly left it as "a separate module and a separate question". Enabling a module that has never been built or exercised deserves a maintainer decision and its own test coverage, not a one-line addition bundled into an unrelated PR. |
| 6 | `max_attempts == 0` is interpreted two ways: `eos_slot_needs_rollback()` treats it as "rollback disabled" and `test_slot_manager.c` pins that, while `eos_boot_policy_select()` has no such guard so zero forces a rollback every boot — and `docs/PRODUCTION_TESTING_REPORT.md` records the latter as intended | `core/boot_policy.c`, `core/slot_manager.c`, docs | Both readings have in-repo support, so which is correct is a design decision, not a bug fix. Choosing one unilaterally would change rollback behaviour on real hardware. Happy to open an issue. |
| 7 | `Dockerfile` `test-runner` stage installs only `pytest`, then runs `pytest tests/` — the same gap as finding 1 | `Dockerfile:23` | Real, but no workflow builds the Dockerfile, so it is dormant. Kept out to keep this PR's scope tight; a one-line follow-up if wanted. |
| 8 | `core/sha512.c` and `core/rollback.c` are each listed twice in `add_library(eboot_core ...)` | `CMakeLists.txt` | Verified harmless: CMake deduplicates, and only one object of each is produced. Maintenance noise, not a defect — not worth touching the root build file for. |
| 9 | The valgrind `foreach` covers 16 of the 20 suites; `test_ecc`, `test_storage`, `test_rollback` and `test_secure_boot` get no valgrind target | `tests/CMakeLists.txt` | Would widen an already-separate cleanup commit, and valgrind could not be run locally to confirm the four suites pass under it. Better as its own change. |
| 10 | `CONTRIBUTING.md` says "19 C unit test suites" and "all 7 unit tests"; there are 20 registered, and `test_secure_boot` is missing from the table | `CONTRIBUTING.md` | Docs-only drift, unrelated to any change here. Belongs in a docs PR. |
| 11 | `.github/PULL_REQUEST_TEMPLATE.md` contains literal control characters that have eaten the first letter of `feat`, `fix`, `refactor`, `test` and `build` | PR template | Same — real and easy to fix, but unrelated to this PR. |
| 12 | `core/keystore.c` emits a `#warning` on every build | `core/keystore.c:29` | **Intentional and left in place.** It fires when a build embeds the RFC 8032 test-vector key as the trust anchor without `EBLDR_PRODUCTION_KEY`, and the comment above it says the warning is deliberate. It is doing its job. This is why the build reports 1 warning rather than 0. |
| 13 | `tests/CMakeLists.txt` uses CRLF line endings throughout, so `git diff --check` flags any added line in it | `tests/CMakeLists.txt` | Added lines match the file's existing endings and contain no real trailing whitespace. Normalising would produce a 148-line whitespace-only diff that buries the actual change. |

---

## Relationship to previous work

The history here is a sequence of correct changes that each left one seam; nothing below was done wrongly.

- **#40 (`8d8ce74`)** introduced `tests/unit/test_sign_image.py` along with the v2 signed-header format. The suite is correct and all of it passes. What did not follow was declaring `cryptography` in the repository requirements or the CI environment — `requirements.txt` was last changed in **#31 (`d3ae185`)**, three days before that suite existed, and no commit has ever named `cryptography` in `requirements.txt` or a workflow. This PR closes that gap.

- **#67 (`ab5a4bf`)** rewrote the boot-log suite so it exercises `core/boot_log.c` rather than its own stubs, and added a fixture that can inject both erase and write failures. The erase path is guarded in `eos_boot_log_clear()` and covered by a test. The write path had the fixture hook but no test, and `eos_boot_log_append()` advanced the head unconditionally. This PR adds the missing test and the matching guard, following the pattern #67 established.

For completeness on the boot log's provenance: **#41 (`cd9793a`)** touched only `ci.yml` and `CMakeLists.txt`, and **#49 (`e3b6d41`)** was a pure `stage1/ → core/` rename with no content change. `eos_boot_log_append()` is byte-identical to its form in the initial `v0.1.0` commit — the unconditional head advance has been there from the start and had only ever been moved.

---

## Limitations

- **CI has not run on this branch yet.** All results above are from local out-of-tree builds on macOS / arm64 with Apple clang 15.0.0, Python 3.13.4 and CMake 4.4.3. Linux/GCC-12 and MSVC behaviour is expected but unverified here; the workflow change will first execute when this PR opens.
- `cryptography>=41.0` is a conservative maintained-release floor, not an API requirement — the APIs used (`Ed25519PrivateKey`, `Ed25519PublicKey`, `serialization`, `InvalidSignature`) have been stable since 2.6. Manylinux wheels exist for the runner's Python, so no build toolchain should be needed.
- The workflow-scanning test parses YAML as text, deliberately, to avoid a PyYAML dependency in the guard itself. It would not understand dependencies installed via a composite action or reusable workflow, and fails loudly if it finds no pytest job at all.
- The boot-log fix is verified against the simulated-flash fixture, not real flash hardware. A failed write still loses that entry — the fix corrects ring *consistency*, not log completeness; changing that would require an API break.
- Cross-compilation, hardware validation, valgrind and `cppcheck`/`clang-tidy` were not run locally (no toolchains; valgrind is unavailable on arm64 macOS).

---

## Recommended follow-ups

In rough order of value, all deliberately kept out of this PR:

1. Decide the `max_attempts == 0` contract and align `boot_policy.c`, `slot_manager.c` and the docs behind one answer.
2. Decide whether `core/fdt_loader.c` is a live module; if so, wire it in together with tests.
3. Apply the same `-r requirements.txt` install to the `Dockerfile` test stage.
4. Refresh the `CONTRIBUTING.md` test counts and repair the PR template's mangled type list.
5. Extend the valgrind target list to the four uncovered suites.

Happy to open issues or follow-up PRs for any of these.

---

## Checklist

- [x] Builds clean in Release and Debug with no new warnings
- [x] All existing tests pass — 20/20 C suites, 36 Python tests
- [x] New tests added, and each confirmed to fail with the fix reverted
- [x] No API, header or ABI change
- [x] No changes to verification, recovery, keystore, stage0 or board code
- [x] Commits follow Conventional Commits and are independently reviewable
