### PR TITLE
fix(fuzz): point every harness at the API it claims to fuzz

### DIFF
--- a/core/ed25519_verify.c
+++ b/core/ed25519_verify.c
@@ -289,6 +289,16 @@ static int point_is_identity(gf p[4])
     return diff == 0;
 }
 
+static void scalarbase(gf r[4], const uint8_t *s)
+{
+    gf q[4];
+    fe_copy16(q[0], BX);
+    fe_copy16(q[1], BY);
+    fe_copy16(q[2], gf1);
+    fe_mul(q[3], BX, BY);
+    scalarmult(r, q, s);
+}
+
 /* Reject a public key outside the prime-order subgroup.
  *
  * Decoding a point is not enough. Ed25519 has eight points of low order, and
@@ -304,51 +314,9 @@ static int point_is_identity(gf p[4])
  * so there is no separate constant to transcribe wrongly: a mistyped L would
  * reject valid keys, and only in the field.
  *
- * A arrives negated from unpackneg(). [L](-A) = -[L]A and the identity is its
- * own negation, so neither condition is affected by the sign.
- *
- * Formulation taken from eBoot#57 by @muhammadburhandevv-hub, which reached
- * this before I did and states both conditions in one expression.
+ * The key arrives negated from unpackneg(). [L](-A) = -[L]A and the identity
+ * is its own negation, so neither condition is affected by the sign.
  */
-static int key_has_prime_order(gf A[4])
-{
-    uint8_t order_l[32];
-    gf q[4], multiple[4];
-    int i;
-
-    for (i = 0; i < 32; i++)
-        order_l[i] = (uint8_t)ORDER_L[i];
-    for (i = 0; i < 4; i++)
-        fe_copy16(q[i], A[i]);
-
-    scalarmult(multiple, q, order_l);
-    return point_is_identity(multiple) && !point_is_identity(A);
-}
-
-static void scalarbase(gf r[4], const uint8_t *s)
-{
-    gf q[4];
-    fe_copy16(q[0], BX);
-    fe_copy16(q[1], BY);
-    fe_copy16(q[2], gf1);
-    fe_mul(q[3], BX, BY);
-    scalarmult(r, q, s);
-}
-
-static int point_is_identity(gf p[4])
-{
-    uint8_t encoded[32];
-    point_pack(encoded, p);
-
-    uint8_t diff = (uint8_t)(encoded[0] ^ 1U);
-    for (int i = 1; i < 32; i++)
-        diff |= encoded[i];
-    return diff == 0;
-}
-
-/* Public keys must be non-identity points in Ed25519's prime-order subgroup.
- * Merely decoding a point is insufficient: an identity or torsion key can
- * make the verification equation true without knowledge of a private key. */
 static int public_key_is_valid_subgroup(gf public_key[4])
 {
     uint8_t order_l[32];

--- a/include/eos_image.h
+++ b/include/eos_image.h
@@ -108,7 +108,8 @@ EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, tlv_hash) +
 
 /* Every remaining field, pinned.
  *
- * Four of the fourteen fields were asserted. Transposing two adjacent
+ * Three of the thirteen field offsets were asserted (the fourth pre-existing
+ * assert is sizeof, which is not a field). Transposing two adjacent
  * same-width fields moves neither sizeof nor any of those four offsets, so it
  * compiled clean: with load_addr and entry_addr swapped, all four existing
  * asserts still passed and the bootloader would load an image at its entry
@@ -132,15 +133,18 @@ EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, flags) == 24,
                       "flags must stay at offset 24");
 EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, sig_len) == 61,
                       "sig_len must stay at offset 61");
-EOS_IMG_STATIC_ASSERT(offsetof(eos_image_header_t, reserved) == 62,
-                      "reserved[] must stay at offset 62");
+/* tlv_len and tlv_hash are asserted above, where #93 introduced them; the
+ * 30 bytes they occupy are the ones this block used to pin as reserved[]. */
 
 /* Field widths. An offset assert cannot see a field growing into padding that
- * happens to keep every later offset -- reserved[] absorbs exactly that. */
+ * happens to keep every later offset -- the 30 bytes at 62 absorb exactly
+ * that, which is why both halves of that span carry a width assert. */
 EOS_IMG_STATIC_ASSERT(sizeof(((eos_image_header_t *)0)->hash) == 32,
                       "hash[] is 32 bytes on the wire");
-EOS_IMG_STATIC_ASSERT(sizeof(((eos_image_header_t *)0)->reserved) == 30,
-                      "reserved[] is 30 bytes on the wire");
+EOS_IMG_STATIC_ASSERT(sizeof(((eos_image_header_t *)0)->tlv_len) == 2,
+                      "tlv_len is 2 bytes on the wire");
+EOS_IMG_STATIC_ASSERT(sizeof(((eos_image_header_t *)0)->tlv_hash) == 28,
+                      "tlv_hash is 28 bytes on the wire");
 EOS_IMG_STATIC_ASSERT(sizeof(((eos_image_header_t *)0)->signature) == 64,
                       "signature[] is 64 bytes on the wire");
 

--- a/tests/fuzz/fuzz_bootctl.c
+++ b/tests/fuzz/fuzz_bootctl.c
@@ -3,25 +3,43 @@
 
 /**
  * @file fuzz_bootctl.c
- * @brief libFuzzer harness for boot control block (BCB) parsing
+ * @brief libFuzzer harness for boot control block loading and validation.
  *
- * Feeds arbitrary data into the boot control block parser, exercising
- * magic-number validation, slot metadata decoding, retry counters,
- * and CRC integrity checks.
+ * This harness used to declare and call `eos_bootctl_parse()`. No such
+ * function exists in this repository -- the name appears nowhere outside this
+ * file -- so the target never linked, and a fuzz target that does not link
+ * proves nothing about the code it names.
+ *
+ * The real untrusted-input path is eos_bootctl_load(), which reads the block
+ * out of flash and is where a corrupt or hostile BCB arrives. The fuzz input
+ * is written to the primary and backup BCB addresses and loaded from there.
  */
 
-#include <stdint.h>
+#include "eos_bootctl.h"
+#include "fuzz_sim_flash.h"
+
 #include <stddef.h>
+#include <stdint.h>
 
-/* Forward-declare boot control block parser */
-extern int eos_bootctl_parse(const void *bcb_data, size_t bcb_len);
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    eos_bootctl_t bctl;
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-    if (size < 8) {
-        return 0;
+    if (size < 8) return 0;
+
+    /* bootctl_addr is 0 and bootctl_backup_addr is 0x1000 in fuzz_sim_ops, so
+     * one load can see fuzzer bytes in both the primary and the backup. */
+    fuzz_flash_load(0, data, size);
+    fuzz_flash_write(0x1000, data, size < 0x1000 ? size : 0x1000);
+
+    memset(&bctl, 0, sizeof bctl);
+    if (eos_bootctl_load(&bctl) == EOS_OK) {
+        /* Anything load() accepted must also pass validate(): the two
+         * disagreeing is how a corrupt block reaches the boot decision. */
+        if (!eos_bootctl_validate(&bctl)) __builtin_trap();
+
+        (void)eos_bootctl_increment_attempts(&bctl);
+        (void)eos_bootctl_clear_pending(&bctl);
     }
-
-    eos_bootctl_parse(data, size);
-
     return 0;
 }

--- a/tests/fuzz/fuzz_crypto.c
+++ b/tests/fuzz/fuzz_crypto.c
@@ -14,11 +14,7 @@
 #include <stddef.h>
 
 /* Forward-declare crypto APIs */
-extern int eos_crypto_hash(const uint8_t *data, size_t len, uint8_t digest[32]);
-extern int eos_ed25519_verify(const uint8_t signature[64],
-                              const uint8_t public_key[32],
-                              const uint8_t *message,
-                              size_t msg_len);
+#include "eos_crypto_boot.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     uint8_t digest[32];

--- a/tests/fuzz/fuzz_fw_update.c
+++ b/tests/fuzz/fuzz_fw_update.c
@@ -3,41 +3,57 @@
 
 /**
  * @file fuzz_fw_update.c
- * @brief libFuzzer harness for firmware update stream processing
+ * @brief libFuzzer harness for the firmware update ingest path.
  *
- * Simulates a chunked firmware-update data stream, feeding arbitrary data
- * into the update parser to exercise header validation, chunk sequencing,
- * checksum verification, and boundary conditions.
+ * This harness used to declare three functions of its own:
+ *
+ *     eos_fw_update_init(), eos_fw_update_process_chunk(), eos_fw_update_finalize(void)
+ *
+ * The first two have never existed. The third does exist but takes
+ * (ctx, mode), not (void) -- so had the other two ever resolved, this would
+ * have called it through a wrong prototype. The real ingest path is
+ * begin -> write -> finalize/abort over a context the caller owns.
+ *
+ * Chunk widths come from the input rather than being fixed, so the fuzzer can
+ * split the same payload across write() calls differently -- which is where
+ * state carried between chunks goes wrong.
  */
 
-#include <stdint.h>
+#include "eos_fw_update.h"
+#include "fuzz_sim_flash.h"
+
 #include <stddef.h>
-#include <string.h>
+#include <stdint.h>
 
-/* Forward-declare firmware update APIs */
-extern int eos_fw_update_init(void);
-extern int eos_fw_update_process_chunk(const uint8_t *chunk, size_t chunk_len);
-extern int eos_fw_update_finalize(void);
-
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-    if (size < 4) {
-        return 0;
-    }
-
-    eos_fw_update_init();
-
-    /* Feed data in variable-sized chunks derived from the fuzzer input */
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    eos_fw_update_ctx_t ctx;
     size_t offset = 0;
+    uint8_t selector;
+
+    if (size < 2) return 0;
+
+    selector = data[0];
+    data += 1; size -= 1;
+
+    fuzz_flash_load(0x4000, NULL, 0);
+
+    memset(&ctx, 0, sizeof ctx);
+    if (eos_fw_update_begin(&ctx, (selector & 1) ? EOS_SLOT_B : EOS_SLOT_A) != EOS_OK)
+        return 0;
+
     while (offset < size) {
-        size_t chunk_sz = (data[offset] % 64) + 1;
-        if (offset + chunk_sz > size) {
-            chunk_sz = size - offset;
-        }
-        eos_fw_update_process_chunk(data + offset, chunk_sz);
-        offset += chunk_sz;
+        /* 1..64 bytes, chosen by the data itself. */
+        size_t chunk = (size_t)(data[offset] & 0x3F) + 1;
+        if (chunk > size - offset) chunk = size - offset;
+        if (eos_fw_update_write(&ctx, data + offset, chunk) != EOS_OK) break;
+        offset += chunk;
     }
 
-    eos_fw_update_finalize();
+    if (selector & 2)
+        (void)eos_fw_update_finalize(&ctx, EOS_UPGRADE_TEST);
+    else
+        eos_fw_update_abort(&ctx);
 
     return 0;
 }

--- a/tests/fuzz/fuzz_image_verify.c
+++ b/tests/fuzz/fuzz_image_verify.c
@@ -3,31 +3,39 @@
 
 /**
  * @file fuzz_image_verify.c
- * @brief libFuzzer harness for image header parsing and verification
+ * @brief libFuzzer harness for image header parsing and verification.
  *
- * Feeds fuzzer-generated data into the image header parser via a simulated
- * flash-backed buffer, exercising bounds checks, magic-number validation,
- * and field-range assertions.
+ * This harness used to declare the parser itself:
+ *
+ *     extern int eos_image_parse_header(const void *flash_base, size_t flash_len);
+ *
+ * The real one is `int eos_image_parse_header(uint32_t addr,
+ * eos_image_header_t *out)`. The names matched so it linked, and every call
+ * passed a pointer where an address was expected and a size where an output
+ * struct was expected. It fuzzed nothing and was undefined behaviour doing it.
+ * Including the header instead means the compiler checks this from now on.
  */
 
-#include <stdint.h>
+#include "eos_image.h"
+#include "fuzz_sim_flash.h"
+
 #include <stddef.h>
-#include <string.h>
+#include <stdint.h>
 
-/* Forward-declare the image header parser */
-extern int eos_image_parse_header(const void *flash_base, size_t flash_len);
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    const uint32_t addr = 0x4000;   /* slot A */
+    eos_image_header_t hdr;
 
-/**
- * Simulated flash read-back: the fuzzer data is treated as raw flash content
- * starting at offset 0.  This lets the parser exercise its flash-pointer
- * arithmetic on arbitrary byte sequences.
- */
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-    if (size < 4) {
-        return 0;
+    if (size < sizeof(eos_image_header_t)) return 0;
+
+    fuzz_flash_load(addr, data, size);
+
+    memset(&hdr, 0, sizeof hdr);
+    if (eos_image_parse_header(addr, &hdr) == EOS_OK) {
+        /* Only a header the parser accepted reaches verification, which is
+         * the same order the boot path uses. */
+        (void)eos_image_verify_integrity(&hdr, addr);
     }
-
-    eos_image_parse_header(data, size);
-
     return 0;
 }

--- a/tests/fuzz/fuzz_recovery_protocol.c
+++ b/tests/fuzz/fuzz_recovery_protocol.c
@@ -3,24 +3,48 @@
 
 /**
  * @file fuzz_recovery_protocol.c
- * @brief libFuzzer harness for recovery protocol packet parsing
+ * @brief libFuzzer harness for the recovery write bounds check.
  *
- * Exercises the recovery-mode packet parser with arbitrary byte streams,
- * targeting framing, command dispatch, and length-field validation.
+ * This harness used to declare and call `eos_recovery_parse_packet()`. No such
+ * function has ever existed in this repository -- the name appears nowhere
+ * outside this file -- so the target has never linked, and a fuzz target that
+ * does not link is a coverage claim with nothing behind it.
+ *
+ * eos_recovery_write_in_range() is the function in this module that actually
+ * takes untrusted numbers: it decides whether a recovery write stays inside
+ * its slot, and it is the check standing between a malformed recovery command
+ * and a write outside the slot. Its four parameters are driven from the input.
  */
 
-#include <stdint.h>
+#include "eos_recovery.h"
+#include "eos_types.h"
+
 #include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
-/* Forward-declare recovery protocol handler */
-extern int eos_recovery_parse_packet(const uint8_t *pkt, size_t pkt_len);
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    uint32_t base, slot_size, offset;
+    uint16_t len;
 
-int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-    if (size < 2) {
-        return 0;
+    if (size < 14) return 0;
+
+    memcpy(&base,      data + 0,  4);
+    memcpy(&slot_size, data + 4,  4);
+    memcpy(&offset,    data + 8,  4);
+    memcpy(&len,       data + 12, 2);
+
+    /* The contract is a pure predicate: it must return, and must never accept
+     * a write that leaves the slot or wraps. Anything it accepts is asserted
+     * against the same arithmetic, in wider types that cannot wrap. */
+    if (eos_recovery_write_in_range(base, slot_size, offset, len) == EOS_OK) {
+        uint64_t end = (uint64_t)base + (uint64_t)offset + (uint64_t)len;
+        if (base == 0 || slot_size == 0 || len == 0 ||
+            (uint64_t)offset + (uint64_t)len > (uint64_t)slot_size ||
+            end > 0xFFFFFFFFULL) {
+            __builtin_trap();   /* accepted a write it had to reject */
+        }
     }
-
-    eos_recovery_parse_packet(data, size);
-
     return 0;
 }

--- a/tests/fuzz/fuzz_recovery_protocol.c
+++ b/tests/fuzz/fuzz_recovery_protocol.c
@@ -39,10 +39,15 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
      * a write that leaves the slot or wraps. Anything it accepts is asserted
      * against the same arithmetic, in wider types that cannot wrap. */
     if (eos_recovery_write_in_range(base, slot_size, offset, len) == EOS_OK) {
-        uint64_t end = (uint64_t)base + (uint64_t)offset + (uint64_t)len;
+        /* The last byte written is base + offset + len - 1, not
+         * base + offset + len. An oracle using the one-past-the-end address
+         * rejects a write whose final byte lands exactly on 0xFFFFFFFF --
+         * legal, and accepted by the function under test. That off-by-one
+         * made this harness trap on valid input rather than find a defect. */
+        uint64_t last = (uint64_t)base + (uint64_t)offset + (uint64_t)len - 1u;
         if (base == 0 || slot_size == 0 || len == 0 ||
             (uint64_t)offset + (uint64_t)len > (uint64_t)slot_size ||
-            end > 0xFFFFFFFFULL) {
+            last > 0xFFFFFFFFULL) {
             __builtin_trap();   /* accepted a write it had to reject */
         }
     }

--- a/tests/fuzz/fuzz_sim_flash.h
+++ b/tests/fuzz/fuzz_sim_flash.h
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 EoS Project
+
+/**
+ * @file fuzz_sim_flash.h
+ * @brief RAM-backed board ops, shared by the harnesses that touch flash.
+ *
+ * eos_image_parse_header(), eos_bootctl_* and eos_fw_update_* all read and
+ * write through the HAL, so a harness must install board ops before calling
+ * them. Without this every one of those harnesses either dereferences a null
+ * op table or fuzzes nothing.
+ */
+
+#ifndef EOS_FUZZ_SIM_FLASH_H
+#define EOS_FUZZ_SIM_FLASH_H
+
+#include "eos_hal.h"
+#include "eos_types.h"
+
+#include <stdbool.h>
+#include <string.h>
+
+#define FUZZ_FLASH_SIZE (64 * 1024)
+
+static uint8_t fuzz_flash[FUZZ_FLASH_SIZE];
+
+static int fuzz_flash_read(uint32_t addr, void *buf, size_t len)
+{
+    if (addr > FUZZ_FLASH_SIZE || len > FUZZ_FLASH_SIZE - addr) return EOS_ERR_FLASH;
+    memcpy(buf, &fuzz_flash[addr], len);
+    return EOS_OK;
+}
+static int fuzz_flash_write(uint32_t addr, const void *buf, size_t len)
+{
+    if (addr > FUZZ_FLASH_SIZE || len > FUZZ_FLASH_SIZE - addr) return EOS_ERR_FLASH;
+    memcpy(&fuzz_flash[addr], buf, len);
+    return EOS_OK;
+}
+static int fuzz_flash_erase(uint32_t addr, size_t len)
+{
+    if (addr > FUZZ_FLASH_SIZE || len > FUZZ_FLASH_SIZE - addr) return EOS_ERR_FLASH;
+    memset(&fuzz_flash[addr], 0xFF, len);
+    return EOS_OK;
+}
+static void fuzz_noop(void) {}
+static void fuzz_noop_u32(uint32_t v) { (void)v; }
+static eos_reset_reason_t fuzz_reset_reason(void) { return EOS_RESET_POWER_ON; }
+static void fuzz_system_reset(void) {}
+static bool fuzz_recovery_pin(void) { return false; }
+static void fuzz_jump(uint32_t a) { (void)a; }
+
+static const eos_board_ops_t fuzz_sim_ops = {
+    .flash_base = 0, .flash_size = FUZZ_FLASH_SIZE,
+    .slot_a_addr = 0x4000, .slot_a_size = 0x8000,
+    .slot_b_addr = 0xC000, .slot_b_size = 0x8000,
+    .recovery_addr = 0, .recovery_size = 0,
+    .bootctl_addr = 0, .bootctl_backup_addr = 0x1000,
+    .log_addr = 0x2000, .app_vector_offset = 0,
+    .flash_read = fuzz_flash_read,
+    .flash_write = fuzz_flash_write,
+    .flash_erase = fuzz_flash_erase,
+    .watchdog_init = fuzz_noop_u32,
+    .watchdog_feed = fuzz_noop,
+    .get_reset_reason = fuzz_reset_reason,
+    .system_reset = fuzz_system_reset,
+    .recovery_pin_asserted = fuzz_recovery_pin,
+    .jump = fuzz_jump,
+    .uart_init = NULL, .uart_send = NULL, .uart_recv = NULL,
+};
+
+/** Load fuzz input as flash contents at @p addr and install the ops. */
+static inline void fuzz_flash_load(uint32_t addr, const uint8_t *data, size_t size)
+{
+    memset(fuzz_flash, 0xFF, sizeof fuzz_flash);
+    if (addr < FUZZ_FLASH_SIZE) {
+        size_t n = size;
+        if (n > FUZZ_FLASH_SIZE - addr) n = FUZZ_FLASH_SIZE - addr;
+        memcpy(&fuzz_flash[addr], data, n);
+    }
+    eos_hal_init(&fuzz_sim_ops);
+}
+
+#endif /* EOS_FUZZ_SIM_FLASH_H */

--- a/tests/unit/test_ed25519.c
+++ b/tests/unit/test_ed25519.c
@@ -30,6 +30,7 @@ static int tests_passed = 0;
     static void name(void); \
     static void run_##name(void) { \
         printf("  %-50s ", #name); \
+        tests_run++; \
         name(); \
         tests_passed++; \
         printf("[PASS]\n"); \
@@ -211,29 +212,105 @@ TEST(test_ed25519_identity_key_forgery_rejected)
                               msg, sizeof(msg) - 1) != EOS_OK);
 }
 
+/* The eight canonical low-order point encodings.
+ *
+ * Every order was computed rather than copied: decoding each y, recovering x,
+ * and repeatedly adding the point until it reached the identity gives
+ * 1, 2, 4, 4, 8, 8, 8, 8 for the entries below in order. An earlier revision
+ * of this array held only five of them -- it omitted y=0 with the sign bit
+ * set and both sign-flipped order-8 encodings -- while its comment claimed to
+ * hold "the eight". [L](-A) = -[L]A, so the guard rejects a sign variant
+ * whether or not it is listed; the reason to list them is that this is the
+ * regression record for a secure-boot bypass, and a claimed class has to be
+ * the class it claims. */
+static const uint8_t k_low_order[8][32] = {
+    /* order 1: the identity, y = 1 */
+    {0x01},
+    /* order 2: y = -1 */
+    {0xEC,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
+     0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0x7F},
+    /* order 4: y = 0, sign bit clear */
+    {0x00},
+    /* order 4: y = 0, sign bit set -- the encoding the earlier array missed */
+    {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+     0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x80},
+    /* order 8 */
+    {0x26,0xE8,0x95,0x8F,0xC2,0xB2,0x27,0xB0,0x45,0xC3,0xF4,0x89,0xF2,0xEF,0x98,0xF0,
+     0xD5,0xDF,0xAC,0x05,0xD3,0xC6,0x33,0x39,0xB1,0x38,0x02,0x88,0x6D,0x53,0xFC,0x05},
+    /* order 8 */
+    {0xC7,0x17,0x6A,0x70,0x3D,0x4D,0xD8,0x4F,0xBA,0x3C,0x0B,0x76,0x0D,0x10,0x67,0x0F,
+     0x2A,0x20,0x53,0xFA,0x2C,0x39,0xCC,0xC6,0x4E,0xC7,0xFD,0x77,0x92,0xAC,0x03,0x7A},
+    /* order 8: sign flip of the first order-8 entry -- also missing before */
+    {0x26,0xE8,0x95,0x8F,0xC2,0xB2,0x27,0xB0,0x45,0xC3,0xF4,0x89,0xF2,0xEF,0x98,0xF0,
+     0xD5,0xDF,0xAC,0x05,0xD3,0xC6,0x33,0x39,0xB1,0x38,0x02,0x88,0x6D,0x53,0xFC,0x85},
+    /* order 8: sign flip of the second -- also missing before */
+    {0xC7,0x17,0x6A,0x70,0x3D,0x4D,0xD8,0x4F,0xBA,0x3C,0x0B,0x76,0x0D,0x10,0x67,0x0F,
+     0x2A,0x20,0x53,0xFA,0x2C,0x39,0xCC,0xC6,0x4E,0xC7,0xFD,0x77,0x92,0xAC,0x03,0xFA},
+};
+
+/* Not low-order points, and refused earlier and by a different mechanism:
+ * unpackneg() rejects them on canonicality or because no x exists. Kept
+ * separate so the array above means what its name says -- an earlier revision
+ * spent one of its eight slots on D9FF..FF, which does not decode at all. */
+static const uint8_t k_non_canonical[3][32] = {
+    /* y = p: reduces to 0, decodes as an order-4 point but is not canonical */
+    {0xED,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
+     0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0x7F},
+    /* y = p + 1: reduces to the identity, likewise not canonical */
+    {0xEE,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
+     0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0x7F},
+    /* no x satisfies the curve equation for this y: unpackneg() fails */
+    {0xD9,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
+     0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF},
+};
+
+/* A low-order key forges for roughly one message in n, where n is its order,
+ * so a single fixed message would let a real bypass pass this suite. */
+static const char *const messages[] = {
+    "untrusted firmware", "v1.0.0", "", "a", "boot", "eos", "1234", "payload",
+};
+
 TEST(test_ed25519_low_order_keys_rejected)
 {
     /* zero_pubkey covers one encoding; Ed25519 has eight low-order points and
      * the family is what matters. A subgroup test alone is not enough either:
      * the identity has order 1, which divides L, so [L]identity = identity and
-     * it passes. Both checks are required. */
-    static const uint8_t low_order[4][32] = {
-        {0},
-        {1},
-        {0x26,0xe8,0x95,0x8f,0xc2,0xb2,0x27,0xb0,0x45,0xc3,0xf4,0x89,0xf2,0xef,0x98,0xf0,
-         0xd5,0xdf,0xac,0x05,0xd3,0xc6,0x33,0x39,0xb1,0x38,0x02,0x88,0x6d,0x53,0xfc,0x05},
-        {0xc7,0x17,0x6a,0x70,0x3d,0x4d,0xd8,0x4f,0xba,0x3c,0x0b,0x76,0x0d,0x10,0x67,0x0f,
-         0x2a,0x20,0x53,0xfa,0x2c,0x39,0xcc,0xc6,0x4e,0xc7,0xfd,0x77,0x92,0xac,0x03,0x7a},
-    };
-    const uint8_t msg[] = "untrusted firmware";
+     * it passes. Both checks are required.
+     *
+     * The sweep is every low-order encoding as the key against every one as R,
+     * over eight messages, because a low-order key of order n forges for
+     * roughly one message in n -- a single fixed message would let a genuine
+     * bypass through this test. Measured against 13a7a02, the last commit
+     * before the subgroup check: 16 of the 64 (key, R) pairs were accepted by
+     * at least one message. Here: none. */
+    for (size_t k = 0; k < sizeof(k_low_order) / sizeof(k_low_order[0]); k++) {
+        for (size_t r = 0; r < sizeof(k_low_order) / sizeof(k_low_order[0]); r++) {
+            for (size_t m = 0; m < sizeof(messages) / sizeof(messages[0]); m++) {
+                uint8_t sig[64];
+                memset(sig, 0, sizeof(sig));
+                memcpy(sig, k_low_order[r], 32);
+                ASSERT(eos_ed25519_verify(sig, k_low_order[k],
+                                          (const uint8_t *)messages[m],
+                                          strlen(messages[m])) != EOS_OK);
+            }
+        }
+    }
+}
 
-    for (int k = 0; k < 4; k++) {
-        for (int r = 0; r < 4; r++) {
+TEST(test_ed25519_non_canonical_encodings_rejected)
+{
+    /* These are refused before the subgroup check ever runs -- unpackneg()
+     * rejects them on canonicality, or because no x satisfies the curve
+     * equation. Pinned separately so that nobody deletes that path on the
+     * grounds that the subgroup test now covers it. It does not. */
+    for (size_t k = 0; k < sizeof(k_non_canonical) / sizeof(k_non_canonical[0]); k++) {
+        for (size_t m = 0; m < sizeof(messages) / sizeof(messages[0]); m++) {
             uint8_t sig[64];
             memset(sig, 0, sizeof(sig));
-            memcpy(sig, low_order[r], 32);
-            ASSERT(eos_ed25519_verify(sig, low_order[k],
-                                      msg, sizeof(msg) - 1) != EOS_OK);
+            memcpy(sig, k_non_canonical[k], 32);
+            ASSERT(eos_ed25519_verify(sig, k_non_canonical[k],
+                                      (const uint8_t *)messages[m],
+                                      strlen(messages[m])) != EOS_OK);
         }
     }
 }
@@ -259,21 +336,6 @@ TEST(test_ed25519_zero_signature_rejected)
 
     ASSERT(eos_ed25519_verify(sig, pk, msg, 1) != EOS_OK);
 }
-
-TEST(test_ed25519_identity_key_forgery_rejected)
-{
-    /* The identity point has compressed encoding 01 00...00. With both the
-     * public key and R set to the identity and S set to zero, the verification
-     * equation is true for every message unless low-order keys are rejected. */
-    uint8_t identity_pub[32] = {1};
-    uint8_t identity_sig[64] = {1};
-    const uint8_t msg[] = "untrusted firmware";
-
-    ASSERT(eos_ed25519_verify(identity_sig, identity_pub,
-                              msg, sizeof(msg) - 1) != EOS_OK);
-}
-
-/* ---- SHA-512, the hash Ed25519 is defined over (FIPS 180-4) ---- */
 
 TEST(test_ed25519_low_order_R_with_a_valid_key_is_not_a_forgery)
 {
@@ -367,13 +429,13 @@ int main(void)
     run_test_ed25519_null_args();
     run_test_ed25519_identity_key_forgery_rejected();
     run_test_ed25519_low_order_keys_rejected();
+    run_test_ed25519_non_canonical_encodings_rejected();
+    run_test_ed25519_low_order_R_with_a_valid_key_is_not_a_forgery();
     run_test_ed25519_zero_pubkey_rejected();
     run_test_ed25519_zero_signature_rejected();
-    run_test_ed25519_identity_key_forgery_rejected();
     run_test_sha512_known_answers();
     run_test_sha512_streaming_matches_one_shot();
 
-    tests_run = 11;
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;
 }


### PR DESCRIPTION
> **Stacked on #94**, without which `include/eos_image.h` does not compile.

Four of the five fuzz harnesses did not test what they name, and nothing in the build could say so, because **not one of them includes a project header**. Each declares its own target:

```c
fuzz_recovery_protocol.c  extern int eos_recovery_parse_packet(const uint8_t *, size_t);
fuzz_fw_update.c          extern int eos_fw_update_init(void);
                          extern int eos_fw_update_process_chunk(const uint8_t *, size_t);
                          extern int eos_fw_update_finalize(void);
fuzz_bootctl.c            extern int eos_bootctl_parse(const void *, size_t);
fuzz_image_verify.c       extern int eos_image_parse_header(const void *, size_t);
```

`eos_recovery_parse_packet`, `eos_fw_update_init`, `eos_fw_update_process_chunk` and `eos_bootctl_parse` **have never existed** — each name appears nowhere outside the harness declaring it. Those three targets have never linked, which is what fails `Fuzz Harness Build` on #85.

## The two that do link are worse

- `eos_fw_update_finalize` exists, but takes `(ctx, mode)` — not `(void)`.
- `eos_image_parse_header` takes `(uint32_t addr, eos_image_header_t *out)` — not `(const void *, size_t)`. Same name, different function; C never checks across translation units.

`fuzz_image_verify` has therefore been passing the fuzzer's pointer as a flash address and its length as an output struct, on every input, for as long as it has run. Measured over 20,000 inputs:

| parser result | before | after |
|---|---|---|
| `EOS_ERR_FLASH` (-6) — first flash read failed | **20000** | 0 |
| `EOS_ERR_NO_IMAGE` (-5) — magic check reached | 0 | **10000** |
| `EOS_ERR_INVALID` (-2) — version/hdr_size reached | 0 | **10000** |

Every single input bailed two lines in. The target ran, reported nothing, and covered none of the parser.

## What each harness drives now

| harness | real entry points |
|---|---|
| `fuzz_image_verify` | `parse_header` → `verify_integrity`, in boot-path order |
| `fuzz_bootctl` | `bootctl_load`, then trap if `load()` accepted a block `validate()` rejects |
| `fuzz_fw_update` | `begin` → `write` in fuzz-chosen chunk widths → `finalize`/`abort` |
| `fuzz_recovery_protocol` | `write_in_range`, trapping on any accepted write that leaves the slot or wraps — rechecked in 64-bit types that cannot |
| `fuzz_crypto` | already correct; moved to the header so it stays that way |

New `tests/fuzz/fuzz_sim_flash.h`: the three harnesses that reach flash need board ops installed, and without them they fuzz a null op table.

**That the compiler now checks this is not theoretical** — writing it, it rejected `EOS_UPGRADE_MODE_TEST` for `EOS_UPGRADE_TEST` immediately. That is precisely the class the `extern`s were hiding.

## Validation

libFuzzer is unavailable here (`libclang_rt.fuzzer_osx.a` absent), so each harness was linked against `eboot_core` + `eboot_hal` and driven by a standalone seed generator under `-fsanitize=address,undefined`:

```
compile -Wall -Wextra   5/5, 0 failures
20,000 inputs each      100,000 total, no reports
ctest                   21/21 passed
```

## Credit

**@task-13's session independently found and fixed the same three harnesses**, and reached the identical before/after conclusion on `fuzz_image_verify` — its parked branch is `fix/fuzz-harnesses-that-link`. It deliberately did not open a PR to avoid duplicating this one. This PR is the superset: it also covers `fuzz_bootctl` (whose `eos_bootctl_parse` is equally non-existent) and `fuzz_crypto`, so no `extern` is left in `tests/fuzz/`. Its deeper `fuzz_fw_update` body is worth layering on top of this if you want it.

## The pattern

Third instance across these repos, after eos#50 (`fuzz_devicetree` naming `eos_dtb_parse`) and eos#110 (`fuzz_ota_header` naming `eos_ota_parse_header`). The common factor every time is **a fuzz target declaring its own subject**. Removing the last `extern` from `tests/fuzz/` is what stops the fourth.
