### PR TITLE
fix(boards): 8051 board port has never compiled — its ops table is not a valid C identifier

### DIFF
--- a/boards/8051/board_8051.c
+++ b/boards/8051/board_8051.c
@@ -20,7 +20,7 @@
 #define MCS8051_RECOVERY      (MCS8051_FLASH_BASE + 2 * MCS8051_FLASH_SIZE / 3)
 #define MCS8051_BOOTCTL       (MCS8051_FLASH_BASE + MCS8051_FLASH_SIZE - 0x2000)
 
-static const eos_board_ops_t 8051_ops = {
+static const eos_board_ops_t mcs8051_ops = {
     .flash_base       = MCS8051_FLASH_BASE,
     .flash_size       = MCS8051_FLASH_SIZE,
     .slot_a_addr      = MCS8051_SLOT_A,
@@ -62,5 +62,5 @@ void board_8051_init_device_table(eos_device_table_t *table)
 
 const eos_board_ops_t *board_8051_get_ops(void)
 {
-    return &8051_ops;
+    return &mcs8051_ops;
 }


### PR DESCRIPTION
## Problem

`boards/8051/board_8051.c` cannot be compiled by any C compiler. The board port
that `CMakeLists.txt:295-296` offers as `-DEBLDR_BOARD=8051` has never been
buildable.

Surfaced by the maintenance sweep's health scan for eBoot, section
*"C — unused functions and dead code"*:

```
boards/8051/board_8051.c:23: error: syntax error: 8051_ops =
```

Reproduced in this worktree before the fix (recorded below as the superseded
first `build-board-8051` run):

```
boards/8051/board_8051.c:23:30: error: invalid suffix '_ops' on integer constant
   23 | static const eos_board_ops_t 8051_ops = {
boards/8051/board_8051.c:65:13: error: invalid suffix '_ops' on integer constant
   65 |     return &8051_ops;
```

## Root cause

The file names its ops table `8051_ops`. A C identifier may not begin with a
digit (C17 §6.4.2.1), so the compiler lexes `8051_ops` as an integer constant
with a bogus suffix. Both the definition at line 23 and the reference at line 65
are rejected.

The sibling ports all use `<board>_ops` — `avr_ops`, `arc_ops`, `m68k_ops` — and
that pattern silently produces an invalid identifier for the one board whose
name starts with a digit. Nothing caught it because no CI job configures with
`EBLDR_BOARD=8051`: the default is `none`, and the board is only compiled when
someone selects it explicitly.

## Fix

Rename the table to `mcs8051_ops`, matching the `MCS8051_*` macro prefix this
same file already uses for its memory map, and update the single reference in
`board_8051_get_ops()`.

`mcs8051_ops` was chosen over `board_8051_ops` because the file's own vocabulary
is already `MCS8051_`, and it keeps the `<something>_ops` shape the other ports
share.

## Files changed

- `boards/8051/board_8051.c` — two lines: the definition and its one reference.

## Expected impact

`cmake -DEBLDR_BOARD=8051` can build `board_8051` for the first time. No other
board, target or configuration is affected — the file is compiled only when that
option is selected.

## Risks and compatibility

Very low. `mcs8051_ops` has internal linkage (`static`), so the rename cannot
affect any other translation unit, and the recorded `refcheck` labels prove
across the whole working root that:

- `8051_ops` appears nowhere outside the file being changed, so nothing was
  depending on the old spelling (it could not have been — it does not compile);
- `mcs8051_ops` was not already in use, so the new name collides with nothing.

No public API, ABI, wire format or manifest entry is touched.

## Verification I could not run here, and why

The full `eboot_core` target does **not** build on `master` in this worktree,
for a reason unrelated to this change: the `_Static_assert`s in
`include/eos_image.h` fail (`expression in static assertion is not an integer`
at `eos_image.h:142`). That breakage is already covered by open PRs #94 and #105,
so it is not addressed here and a whole-project build label is deliberately not
recorded rather than recorded as something it is not.

Verification is therefore scoped to the target this change actually affects:
`board_8051` compiles, where before it did not. `ctest` was not run for the same
reason — the test targets depend on `eboot_core`.

## Not covered by this change

The 8051 memory map in this file looks wrong independently of the identifier
bug — `MCS8051_FLASH_SIZE` is 8 KiB, but `MCS8051_SLOT_A` is `FLASH_BASE +
0x20000` and `MCS8051_BOOTCTL` computes to address 0, both outside the declared
flash region. Those are values a maintainer has to choose against real STC89C52
part documentation, not something to guess at in a compile fix, so they are
recorded in the sweep backlog instead.

## Verification

Executed in an isolated worktree branched from `origin/master`:

| Check | Result | Duration | Command |
|---|---|---|---|
| `build-board-8051` | pass | 1s | `cmake --build build/8051 --target board_8051` |
| `configure` | pass | 0s | `cmake -B build/8051 -G Ninja -DEBLDR_BOARD=8051` |
| `refcheck` | pass | 1s | `/home/srpatcha/eos/.ai/autoreview/refcheck.sh 8051_ops --exclude boards/8051/board_8051.c` |
| `refcheck-newname` | pass | 0s | `/home/srpatcha/eos/.ai/autoreview/refcheck.sh mcs8051_ops --exclude boards/8051/board_8051.c` |


---
*Opened by the scheduled autoreview pipeline (model `claude-opus-5`), branched from `origin/master`. No human has reviewed this yet. Close it freely if the fix is wrong - a bad automated PR is a bug worth reporting.*
