### PR TITLE
fix(imgpack): reject version components that overflow the uint32 encoding

### DIFF
--- a/tests/unit/test_imgpack.py
+++ b/tests/unit/test_imgpack.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 EoS Project
+
+"""Tests for imgpack.py version encoding.
+
+The bootloader compares image_version as a plain uint32 for anti-rollback
+(eos_image_check_version / eos_image_check_rollback), using the layout from
+EOS_VERSION_MAKE in include/eos_types.h: 8-bit major, 8-bit minor, 16-bit
+patch. A component that does not fit its field must be rejected: silently
+masking or carrying it produces a header that misorders against other images
+(e.g. '1.256.0' used to encode identically to '2.0.0', and '1.0.65536'
+identically to '1.0.0' — numerically *older* than 1.0.1).
+"""
+
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOLS = REPO_ROOT / "tools"
+
+IMAGE_VERSION_OFFSET = 20
+
+
+def _pack(tmp_path, version):
+    (tmp_path / "fw.bin").write_bytes(b"\x5A" * 256)
+    return subprocess.run(
+        [sys.executable, str(TOOLS / "imgpack.py"),
+         "--input", str(tmp_path / "fw.bin"),
+         "--output", str(tmp_path / "fw.eimg"),
+         "--load-addr", "0x08010000", "--entry-addr", "0x08010100",
+         "--version", version],
+        capture_output=True, text=True)
+
+
+def test_in_range_version_encodes_correctly(tmp_path):
+    r = _pack(tmp_path, "1.2.3")
+    assert r.returncode == 0, r.stderr
+    data = (tmp_path / "fw.eimg").read_bytes()
+    encoded = struct.unpack_from("<I", data, IMAGE_VERSION_OFFSET)[0]
+    assert encoded == (1 << 24) | (2 << 16) | 3
+
+
+def test_max_components_encode_correctly(tmp_path):
+    r = _pack(tmp_path, "255.255.65535")
+    assert r.returncode == 0, r.stderr
+    data = (tmp_path / "fw.eimg").read_bytes()
+    encoded = struct.unpack_from("<I", data, IMAGE_VERSION_OFFSET)[0]
+    assert encoded == 0xFFFFFFFF
+
+
+@pytest.mark.parametrize("version", [
+    "256.0.0",      # major does not fit 8 bits
+    "1.256.0",      # minor carries into major: used to equal 2.0.0
+    "1.0.65536",    # patch truncated to 0: used to encode older than 1.0.1
+    "-1.0.0",       # negative major
+    "1.0.-1",       # negative patch: used to encode as patch 65535
+])
+def test_out_of_range_version_is_rejected(tmp_path, version):
+    r = _pack(tmp_path, version)
+    assert r.returncode != 0, (
+        f"version '{version}' was accepted:\n{r.stdout}")
+    assert not (tmp_path / "fw.eimg").exists(), (
+        f"output image was written for rejected version '{version}'")
+    assert "out of range" in r.stderr

--- a/tools/imgpack.py
+++ b/tools/imgpack.py
@@ -31,12 +31,24 @@ SIG_CRC32 = 1
 
 
 def parse_version(version_str: str) -> int:
-    """Parse 'major.minor.patch' into uint32 encoding."""
+    """Parse 'major.minor.patch' into uint32 encoding.
+
+    Matches EOS_VERSION_MAKE in include/eos_types.h: 8-bit major, 8-bit
+    minor, 16-bit patch. The bootloader compares the encoded uint32
+    numerically for anti-rollback, so an out-of-range component must be an
+    error — silently masking or carrying it would misorder versions
+    (e.g. '1.256.0' would encode identically to '2.0.0', and a truncated
+    patch would encode as an *older* image).
+    """
     parts = version_str.split('.')
     if len(parts) != 3:
         raise ValueError(f"Version must be major.minor.patch, got '{version_str}'")
     major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
-    return (major << 24) | (minor << 16) | (patch & 0xFFFF)
+    if not (0 <= major <= 0xFF and 0 <= minor <= 0xFF and 0 <= patch <= 0xFFFF):
+        raise ValueError(
+            f"Version components out of range in '{version_str}' "
+            f"(major/minor: 0-255, patch: 0-65535)")
+    return (major << 24) | (minor << 16) | patch
 
 
 def compute_crc32(data: bytes) -> int:
@@ -101,7 +113,11 @@ def main():
 
     load_addr = int(args.load_addr, 16)
     entry_addr = int(args.entry_addr, 16)
-    image_version = parse_version(args.version)
+    try:
+        image_version = parse_version(args.version)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
     flags = int(args.flags, 16)
     image_crc = compute_crc32(firmware_data)
 


### PR DESCRIPTION
## Issue

`parse_version()` in `tools/imgpack.py` packed `major.minor.patch` into the header's `image_version` field without checking that each component fits the `EOS_VERSION_MAKE` layout (8/8/16 bits). Out-of-range input was silently misencoded: `1.256.0` became indistinguishable from `2.0.0`, `1.0.65536` from `1.0.0` (numerically older than `1.0.1`), and a negative patch like `1.0.-1` became patch 65535 — the maximum. Since the bootloader compares `image_version` numerically for anti-rollback (`eos_image_check_rollback`, `eos_image_check_version`) and raises a fuse-backed floor on confirm, a misencoded version can wrongly block legitimate updates or wrongly raise the floor above future builds.

## Approach

Validate each component against its field width in `parse_version()` and raise `ValueError`; `main()` reports it cleanly and exits 1 before any output is written. In-range versions encode byte-for-byte identically to before.

## Testing / validation

- Static review of the encoding contract against `include/eos_types.h` and the rollback call sites; both changed files pass `py_compile`.
- Added `tests/unit/test_imgpack.py` (pytest, subprocess-style matching the existing `test_sign_image.py`) covering correct encoding at the boundaries and rejection of the overflow/negative cases.
- The tests were written for CI to run; they were not executed locally.

## Limitations

Fixes only the tool-side encoding; the C `EOS_VERSION_MAKE` macro still masks rather than rejects (acceptable there — its inputs are compile-time constants). `eos_sign.py --version` takes a raw integer and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
