### PR TITLE
fix(stage0): return after failed stage1 hash verification

### DIFF
--- a/stage0/jump_stage1.c
+++ b/stage0/jump_stage1.c
@@ -94,6 +94,11 @@ void ebldr_stage0_main(void)
         if (match1 || match2) {
             eos_boot_log_append(EOS_LOG_BOOT_FAIL, EOS_SLOT_NONE, 0xBAD1);
             eos_recovery_enter(&bctl);
+            /* eos_recovery_enter() only returns if it decides to reboot rather
+            * than halt. Either way, a Stage-1 that just failed its integrity
+            * check must never be jumped into — return so the corrupted image
+            * is never entered. */
+           return;
         }
         eos_boot_log_append(EOS_LOG_IMAGE_VALID, EOS_SLOT_NONE, 0);
 #endif


### PR DESCRIPTION
## Summary

Fix fail-open in Stage-1 integrity check — a hash mismatch was logged and routed to recovery, but execution still fell through and jumped into the unverified Stage-1 image if eos_recovery_enter() returned.


## Type of Change
 — Bug fix


## Changes
stage0/jump_stage1.c: add return; after eos_recovery_enter() in the mismatch branch, so a failed integrity check can no longer fall through to ops->jump(stage1_addr).


## Testing
Manual testing performed

## Related Issues
 Related to the fail-open fixes in secure_boot.c and jump_app.c
