### PR TITLE
Remove duplicate FDT loader test target

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -184,11 +184,6 @@ target_link_libraries(eboot_test_ecc PRIVATE eboot_core)
 add_test(NAME test_ecc COMMAND eboot_test_ecc)
 list(APPEND EBLDR_UNIT_TESTS test_ecc)
 
-# --- test_fdt_loader: device tree parsing against malformed blobs ---
-# core/fdt_loader.c was in no source list, so it had never been compiled.
-add_executable(eboot_test_fdt_loader unit/test_fdt_loader.c)
-target_link_libraries(eboot_test_fdt_loader PRIVATE eboot_core)
-add_test(NAME test_fdt_loader COMMAND eboot_test_fdt_loader)
 
 # --- test_fw_decrypt: Streaming AES-256-GCM firmware decryption ---
 # Anchored here rather than after test_keystore: #82 inserts its own


### PR DESCRIPTION
## Summary

* Remove the duplicate `eboot_test_fdt_loader` target and `test_fdt_loader` registration from `tests/CMakeLists.txt`.
* Keep the existing FDT loader test definition unchanged.

## Testing

* `cmake -S . -B build/host -DEBLDR_BUILD_TESTS=ON` — passed.
* Host build reaches pre-existing baseline errors in `core/ed25519_verify.c` and `core/sha512.c`.
* These build failures are unrelated to this change.
