### PR TITLE
ci: fail test jobs when no tests are registered

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         run: cmake --build build --parallel
 
       - name: Run tests
-        run: ctest --test-dir build --output-on-failure
+        run: ctest --test-dir build --output-on-failure --no-tests=error
 
   build-arm:
     name: Cross-compile STM32F4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Test
-        run: ctest --test-dir build --output-on-failure -C Release
+        run: ctest --test-dir build --output-on-failure --no-tests=error -C Release
 
   cross-compile:
     name: Cross (${{ matrix.arch }})
@@ -126,7 +126,7 @@ jobs:
         env:
           ASAN_OPTIONS: detect_leaks=1:halt_on_error=1:abort_on_error=1
           UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
-        run: ctest --test-dir build-san --output-on-failure
+        run: ctest --test-dir build-san --output-on-failure --no-tests=error
 
   report:
     name: Nightly Report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           cmake -B build -DEBLDR_BUILD_TESTS=ON -DEBLDR_HARDENING=ON
           cmake --build build --parallel
-          ctest --test-dir build --output-on-failure
+          ctest --test-dir build --output-on-failure --no-tests=error
 
   firmware-arm-cortex-m:
     name: Firmware (${{ matrix.board }})

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build
         run: cmake --build build --config Release
       - name: Test
-        run: ctest --test-dir build --output-on-failure -C Release
+        run: ctest --test-dir build --output-on-failure --no-tests=error -C Release
 
   cross-compile:
     name: Cross (${{ matrix.arch }})


### PR DESCRIPTION
## Summary

Make all CTest-based CI jobs fail when no tests are registered.

## Motivation

CTest can exit successfully when no tests are registered, which can allow a test-registration or configuration regression to appear as a passing CI job.

The repository already uses `--no-tests=error` in `ci.yml`, and existing regression tests and git history show that dropped test registrations have previously resulted in CI passing with fewer tests than intended.

## Changes

Add `--no-tests=error` to the five remaining CTest invocations in:

* `build.yml`
* `nightly.yml`
* `release.yml`
* `weekly.yml`

No change is made to `ci.yml` because it already uses the guard.

## Verification

* Confirmed all CTest workflow invocations configure `EBLDR_BUILD_TESTS=ON`.
* Confirmed no workflow intentionally runs CTest with tests disabled.
* Ran `git diff --check`.
* The GitHub Actions workflows will provide CI validation for the changed commands.
