### PR TITLE
chore: community governance rollout

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,6 +47,11 @@
 <!-- Reference related issues: Closes #XX, Fixes #YY -->
 
 
+## Closing issue
+
+Fixes #<same-repository issue number>
+
+
 ## Screenshots / Logs
 
 <!-- If applicable, add screenshots or relevant log output -->

--- a/.github/workflows/linked-issue.yml
+++ b/.github/workflows/linked-issue.yml
@@ -1,0 +1,16 @@
+name: Linked issue policy
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  policy:
+    uses: embeddedos-org/.github/.github/workflows/linked-issue-policy.yml@92cb596c773496ec4df76717e8acf0e6b7700f73
+    with:
+      policy_ref: 92cb596c773496ec4df76717e8acf0e6b7700f73

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,98 +1,75 @@
-<!-- generated: eos-ai-scaffold -->
-# Agent Responsibilities
+# AGENTS.md — eBoot
 
-Each role owns a slice of the work and does only that slice. Full briefs are in
-[.ai/](./.ai/). These are responsibilities, not a required agent count — one
-agent may hold several roles on a small change. Split when the roles need
-genuinely different context, not by default.
+eBoot (CMake project `eBootloader`, v3.0.2) is a multi-platform, modular secure
+bootloader written in C: a minimal Stage-0 (early hardware bring-up) plus a
+Stage-1 that scans, selects, verifies (Ed25519), and jumps to an application or
+RTOS image, with A/B slot management, recovery, and firmware-update transports.
+(Provenance: `README.md` intro.)
 
-One rule is structural rather than stylistic: **whoever implements does not
-approve.** Review is a separate role because self-review reliably misses the
-thing the implementer already believes is correct.
+## Layout (from `README.md` "What's inside")
 
-## Planner — [.ai/planner.md](./.ai/planner.md)
+- `stage0/` — reset entry, hardware init, watchdog, recovery entry, jump to Stage-1
+- `stage1/` — boot logic: scan, select, boot log, jump to app (`main.c`)
+- `core/` — platform-agnostic boot logic (Ed25519 verify, image TLV/verify, slot
+  manager, keystore, anti-rollback, firmware update/decrypt, UART transport,
+  boot policy/menu, recovery); builds `eboot_core`
+- `hal/` — HAL dispatch and board registry; builds `eboot_hal`
+- `include/` — public headers (`eos_secure_boot.h`, `eos_image.h`, …)
+- `boards/` — per-architecture board support
+- `configs/` — boot/flash/image YAML schemas and flash-tool config
+- `toolchains/` — cross-compile toolchain files (aarch64, arm-none-eabi, riscv64, …)
+- `tests/` — `unit/`, `functional/`, `fuzz/`, `performance/`, `simulation/`
+- `docs/` — quickstart, architecture, secure boot chain, threat model, etc.
 
-- Understand the request.
-- Break work into tasks.
-- Assign work.
+## Build (from `README.md` "Build" and `CONTRIBUTING.md` "Development Setup")
 
-## Architect — [.ai/architect.md](./.ai/architect.md)
+Requires CMake ≥ 3.15 and a C compiler. Native build compiles the
+platform-agnostic core libraries (no architecture-specific code; works on
+Linux, macOS, Windows). Tests are disabled by default; enable with
+`EBLDR_BUILD_TESTS=ON`.
 
-- Design structure.
-- Choose patterns.
-- Own dependencies, scalability and maintainability.
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DEBLDR_BUILD_TESTS=ON
+cmake --build build --parallel
+```
 
-## Backend — [.ai/backend.md](./.ai/backend.md)
+Cross-compile for a target board with `EBLDR_BOARD` plus a toolchain file:
 
-- APIs
-- Database
-- Business logic
+```bash
+cmake -B build/stm32 -DEBLDR_BOARD=stm32f4 \
+  -DCMAKE_TOOLCHAIN_FILE=toolchains/arm-none-eabi.cmake
+cmake --build build/stm32 --parallel
+```
 
-## Frontend — [.ai/frontend.md](./.ai/frontend.md)
+## Test (from `README.md` "Test" and `CONTRIBUTING.md` "Test Suites")
 
-- UI
-- Components
-- Accessibility
+```bash
+cmake -S . -B build -DEBLDR_BUILD_TESTS=ON
+cmake --build build --parallel
+ctest --test-dir build --output-on-failure
+python run_all_tests.py
+```
 
-## Testing — [.ai/testing.md](./.ai/testing.md)
+Python tooling setup: `pip install -r requirements.txt`. Config-generation
+check: `python scripts/generate_config.py configs/example_boot.yaml /tmp/generated/`.
 
-- Unit tests
-- Integration tests
-- Regression tests
+## Lint / format
 
-## Security — [.ai/security.md](./.ai/security.md)
+Not defined: no lint or format command is documented in `README.md` or
+`CONTRIBUTING.md`. (A `.clang-tidy` config file exists in the tree, but the
+repo documents no command to invoke it; C style rules — C11, `-Wall -Wextra`
+clean — are in `CONTRIBUTING.md` "Code Guidelines".)
 
-- Authentication and authorization
-- Validation
-- Secrets
-- Dependency review
+## Contributing
 
-## Performance — [.ai/performance.md](./.ai/performance.md)
+See `CONTRIBUTING.md`: fork, create a feature branch (`git checkout -b
+feat/my-feature`), run the build and tests locally, then submit a pull request.
+Follow Conventional Commits; new features need unit tests in `tests/unit/`
+(registered with both `add_executable()` and `add_test()` in
+`tests/CMakeLists.txt`).
 
-- Profiling
-- Optimization
-- Scalability
+## Security
 
-## Reviewer — [.ai/reviewer.md](./.ai/reviewer.md)
-
-- Final review
-- Verify requirements
-- Merge findings
-
-## Documentation — [.ai/docs.md](./.ai/docs.md)
-
-- README
-- API docs
-- Changelog
-- Migration and architecture notes
-
-## Release — [.ai/release.md](./.ai/release.md)
-
-- Release notes
-- Deployment preparation
-- Rollback guidance
-
----
-
-## Switching roles
-
-Switch when the task changes domain, when specialist knowledge is required,
-when independent review is required, or when the context has grown past what
-one agent can hold accurately. Every switch runs the protocol in
-[HANDOFF.md](./HANDOFF.md).
-
-## Finding work that is not yours
-
-You will. The rule is: **record it, do not absorb it, do not drop it.**
-
-| What you found | Do |
-|----------------|-----|
-| A defect unrelated to your task | Note it in [TASKS.md](./TASKS.md) and keep going. |
-| A defect your change would sit on top of | Stop; say it blocks you; propose fixing it as its own task. |
-| A security issue | Report immediately, whatever role you hold. This one never waits for a handoff. |
-| A design decision missing from the plan | Return to the architect rather than deciding it inside an implementation. |
-| Work that belongs to a role nobody assigned | Say so. An unowned task is how requirements go missing. |
-
-Silently fixing something outside your task makes the diff unreviewable.
-Silently ignoring it means nobody ever looks again. Neither is acceptable; the
-note is what makes the difference.
+See `SECURITY.md`. Report vulnerabilities to security@embeddedos.org — do NOT
+open public issues for vulnerabilities. Response SLA: acknowledgment within
+48 hours; 90-day coordinated disclosure.

--- a/docs/wiki/Development.md
+++ b/docs/wiki/Development.md
@@ -1,0 +1,55 @@
+# Development
+
+## Contribution source of truth
+
+[CONTRIBUTING](https://github.com/embeddedos-org/eBoot/blob/master/CONTRIBUTING.md)
+
+Before proposing a change, also review the [README](https://github.com/embeddedos-org/eBoot/blob/master/README.md). Keep changes scoped, add tests appropriate to the affected behavior, and follow the repository's current automation and review requirements.
+
+## Build and dependency inputs found
+
+`CMakeLists.txt`, `Dockerfile`, `build_sim/Makefile`, `requirements.txt`, `tests/CMakeLists.txt`, `tests/fuzz/CMakeLists.txt`.
+
+## Tests found in the default-branch tree
+
+`ci/security_test.sh`, `tests/CMakeLists.txt`, `tests/__init__.py`, `tests/functional/__init__.py`, `tests/functional/test_functional_e2e.py`, `tests/fuzz/CMakeLists.txt`, `tests/fuzz/fuzz_bootctl.c`, `tests/fuzz/fuzz_crypto.c`, `tests/fuzz/fuzz_fdt.c`, `tests/fuzz/fuzz_fw_update.c`, `tests/fuzz/fuzz_image_verify.c`, `tests/fuzz/fuzz_recovery_protocol.c`, and 59 more.
+
+## Documented test commands
+
+These commands are reproduced from the inspected root README or contributing guide:
+
+```bash
+cmake -S . -B build \
+```
+
+```bash
+cmake --build build --parallel
+```
+
+```bash
+ctest --test-dir build --output-on-failure
+```
+
+```bash
+cmake -B build/stm32 \
+```
+
+```bash
+cmake --build build/stm32 --parallel
+```
+
+```bash
+cmake -S . -B build -DEBLDR_BUILD_TESTS=ON
+```
+
+```bash
+cmake -B build -DEBLDR_BUILD_TESTS=ON
+```
+
+```bash
+cmake --build build
+```
+
+## Verification baseline
+
+This inventory comes from `master` at [`b42935469821`](https://github.com/embeddedos-org/eBoot/commit/b42935469821343b972738690e3d3a925c223edf) and found 71 test-related paths among 540 files. Re-check the source tree when that commit is no longer current.

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -1,0 +1,29 @@
+# FAQ
+
+## What is `eBoot`?
+
+[](https://github.com/embeddedos-org/eBoot/actions/workflows/ci.yml) [](https://github.com/embeddedos-org/eBoot/actions/workflows/codeql.yml) [](https://github.com/embeddedos-org/eBoot/actions/workflows/scorecard.yml) [](https://github.com/embeddedos-org/eBoot/actions/workflows/release.yml) [](LICENSE)
+
+## Which branch does this wiki describe?
+
+The latest publication inspected `master` at [`b42935469821`](https://github.com/embeddedos-org/eBoot/commit/b42935469821343b972738690e3d3a925c223edf).
+
+## Where are setup instructions?
+
+Start with the [README](https://github.com/embeddedos-org/eBoot/blob/master/README.md), then use [Getting Started](Getting-Started) for a concise map of the checked-in project inputs.
+
+## How do I contribute?
+
+Use the [CONTRIBUTING](https://github.com/embeddedos-org/eBoot/blob/master/CONTRIBUTING.md) and the evidence-backed inventory on [Development](Development). If no root contributing guide exists, inspect the README, repository automation, and recent accepted changes before proposing work.
+
+## How do I run tests?
+
+[Development](Development) lists the 71 test-related paths found in the inspected tree and reproduces recognized test commands only when they appear in the root README or contributing guide.
+
+## How do I report a security issue?
+
+Follow [Security](Security). The source-tree policy status for this publication is: [SECURITY](https://github.com/embeddedos-org/eBoot/blob/master/SECURITY.md)
+
+## Is the wiki authoritative?
+
+No. The [embeddedos-org/eBoot source tree](https://github.com/embeddedos-org/eBoot) is authoritative. The wiki is a repository-specific guide to that source.

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,0 +1,28 @@
+# Getting Started
+
+## Repository purpose
+
+[](https://github.com/embeddedos-org/eBoot/actions/workflows/ci.yml) [](https://github.com/embeddedos-org/eBoot/actions/workflows/codeql.yml) [](https://github.com/embeddedos-org/eBoot/actions/workflows/scorecard.yml) [](https://github.com/embeddedos-org/eBoot/actions/workflows/release.yml) [](LICENSE)
+
+## First steps
+
+1. Read the [README](https://github.com/embeddedos-org/eBoot/blob/master/README.md) for the project's supported setup and usage path.
+2. Clone the repository and enter its directory:
+
+```bash
+git clone https://github.com/embeddedos-org/eBoot.git
+cd eBoot
+```
+
+3. Check the root project inputs below before installing dependencies or selecting a build tool.
+4. Review [Development](Development) before changing code, and [Security](Security) before reporting a vulnerability.
+
+## Root project inputs
+
+- `CMakeLists.txt`: CMake build definition.
+- `Dockerfile`: Container build definition.
+- `requirements.txt`: Python requirements.
+
+## Scope note
+
+The default branch inspected for this page was `master` at [`b42935469821`](https://github.com/embeddedos-org/eBoot/commit/b42935469821343b972738690e3d3a925c223edf). This page intentionally does not invent a universal build command when the repository's own documentation does not provide one.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,22 @@
+# eBoot
+
+[](https://github.com/embeddedos-org/eBoot/actions/workflows/ci.yml) [](https://github.com/embeddedos-org/eBoot/actions/workflows/codeql.yml) [](https://github.com/embeddedos-org/eBoot/actions/workflows/scorecard.yml) [](https://github.com/embeddedos-org/eBoot/actions/workflows/release.yml) [](LICENSE)
+
+This wiki is a maintained navigation layer for [embeddedos-org/eBoot](https://github.com/embeddedos-org/eBoot). Source files on the `master` default branch remain authoritative for code, commands, policies, and release behavior.
+
+## Start here
+
+- [Getting Started](Getting-Started) explains how to orient yourself using the repository's checked-in entry points.
+- [Development](Development) records the build manifests, contribution guidance, and tests found during the latest source inspection.
+- [Security](Security) points to the repository's vulnerability-reporting policy.
+- [FAQ](FAQ) answers common repository-specific navigation questions.
+
+## Source snapshot
+
+- Default branch: `master`
+- Inspected source commit: [`b42935469821`](https://github.com/embeddedos-org/eBoot/commit/b42935469821343b972738690e3d3a925c223edf)
+- Root project overview: [README](https://github.com/embeddedos-org/eBoot/blob/master/README.md)
+- Contribution guidance: [CONTRIBUTING](https://github.com/embeddedos-org/eBoot/blob/master/CONTRIBUTING.md)
+- Security policy: [SECURITY](https://github.com/embeddedos-org/eBoot/blob/master/SECURITY.md)
+
+The wiki was generated from repository content, but it does not replace that content. If a wiki statement and the source tree disagree, follow the source tree and open a documentation correction.

--- a/docs/wiki/Security.md
+++ b/docs/wiki/Security.md
@@ -1,0 +1,13 @@
+# Security
+
+## Reporting vulnerabilities
+
+The repository has a root [SECURITY](https://github.com/embeddedos-org/eBoot/blob/master/SECURITY.md). Follow that policy for supported versions, reporting channels, disclosure expectations, and response details.
+
+Do not publish suspected vulnerabilities in a public issue unless the policy explicitly directs you to do so. Provide a clear description, affected versions or commits, reproduction details, impact, and any known mitigation through the private channel named by the policy.
+
+## Evidence
+
+- Repository: [embeddedos-org/eBoot](https://github.com/embeddedos-org/eBoot)
+- Inspected branch: `master`
+- Inspected commit: [`b42935469821`](https://github.com/embeddedos-org/eBoot/commit/b42935469821343b972738690e3d3a925c223edf)

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,8 @@
+**eBoot Wiki**
+
+- [Home](Home)
+- [Getting Started](Getting-Started)
+- [Development](Development)
+- [Security](Security)
+- [FAQ](FAQ)
+- [Source Repository](https://github.com/embeddedos-org/eBoot)


### PR DESCRIPTION
## Closing issue

Fixes #113

## Summary

Community governance rollout for eBoot:

- `AGENTS.md` — repo-specific agent guide (project description from README, actual layout, build/test commands with file provenance, contribution pointer to CONTRIBUTING.md, security pointer to SECURITY.md). No placeholder commands; lint/format truthfully reported as not defined.
- `docs/wiki/` — 6 wiki pages copied byte-for-byte (Development, FAQ, Getting-Started, Home, Security, _Sidebar).
- `.github/workflows/linked-issue.yml` — linked-issue policy workflow pinned to `92cb596c773496ec4df76717e8acf0e6b7700f73` (placeholder count 0, SHA occurs 2x, YAML parses).
- `.github/PULL_REQUEST_TEMPLATE.md` — repo-specific content preserved verbatim; added one canonical top-level `## Closing issue` section.

## Validation notes

- Wiki files byte-equal to source (matching git blob hashes on both sides).
- Native core build configures cleanly; MSVC compile of the repo tree has pre-existing upstream errors unrelated to this rollout (`ed25519_verify.c` duplicate `scalarbase`, `sha512.c` `eos_sha512_ctx_t.count`, `keystore.c` `#warning`). Test configure has a pre-existing duplicate `eboot_test_fdt_loader` target in `tests/CMakeLists.txt`, untouched here.
- No merge requested; draft for review.
